### PR TITLE
feat: part-based messages, reasoning SSE, visibility toggles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ Thumbs.db
 # Temporary files
 .tmp*
 
+# Build/test cache
+.cache/
+
 # Reference repos (cloned for study, not part of this project)
 reference/
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -12,6 +12,7 @@ import (
 )
 
 // EventType identifies the kind of agent loop event.
+// Ordinals differ from provider.EventType — these are separate iota sequences.
 type EventType int
 
 const (

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stephenbrandon/ripcode/internal/provider"
 	"github.com/stephenbrandon/ripcode/internal/session"
+	"github.com/stephenbrandon/ripcode/internal/store"
 	"github.com/stephenbrandon/ripcode/internal/tool"
 )
 
@@ -163,6 +164,9 @@ func (l *Loop) consumeStream(ctx context.Context, streamCh <-chan provider.Strea
 		case provider.EventError:
 			ch <- Event{Type: EventError, Error: event.Error}
 			return content.String(), toolCalls, meta
+
+		default:
+			store.LogError(fmt.Sprintf("loop: unknown provider event type %d", event.Type), nil)
 		}
 	}
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -47,9 +47,9 @@ type Event struct {
 func (e Event) Valid() error {
 	switch e.Type {
 	case EventContentDelta:
-		// Content may be empty
+		// Content may be empty (whitespace-only deltas are valid in SSE streams)
 	case EventReasoningDelta:
-		// Content may be empty
+		// Content may be empty (whitespace-only deltas are valid in SSE streams)
 	case EventToolStart:
 		if e.Tool == nil {
 			return fmt.Errorf("tool start event missing Tool")
@@ -68,6 +68,36 @@ func (e Event) Valid() error {
 		return fmt.Errorf("unknown event type: %d", e.Type)
 	}
 	return nil
+}
+
+// NewContentEvent creates a content delta event.
+func NewContentEvent(content string) Event {
+	return Event{Type: EventContentDelta, Content: content}
+}
+
+// NewReasoningEvent creates a reasoning delta event.
+func NewReasoningEvent(content string) Event {
+	return Event{Type: EventReasoningDelta, Content: content}
+}
+
+// NewToolStartEvent creates a tool start event.
+func NewToolStartEvent(t *ToolEvent) Event {
+	return Event{Type: EventToolStart, Tool: t}
+}
+
+// NewToolEndEvent creates a tool end event.
+func NewToolEndEvent(t *ToolEvent) Event {
+	return Event{Type: EventToolEnd, Tool: t}
+}
+
+// NewDoneEvent creates a done event with optional metadata.
+func NewDoneEvent(meta *provider.Metadata) Event {
+	return Event{Type: EventDone, Meta: meta}
+}
+
+// NewErrorEvent creates an error event.
+func NewErrorEvent(err error) Event {
+	return Event{Type: EventError, Error: err}
 }
 
 // Loop orchestrates the agent's prompt-stream-tool cycle.
@@ -108,7 +138,7 @@ func (l *Loop) run(ctx context.Context, input string, ch chan<- Event) {
 	for step := 0; step < l.maxSteps; step++ {
 		select {
 		case <-ctx.Done():
-			ch <- Event{Type: EventError, Error: ctx.Err()}
+			ch <- NewErrorEvent(ctx.Err())
 			return
 		default:
 		}
@@ -116,7 +146,7 @@ func (l *Loop) run(ctx context.Context, input string, ch chan<- Event) {
 		toolDefs := l.agent.FilterRegistry(l.registry)
 		streamCh, err := l.provider.Chat(ctx, l.session.History(), toolDefs)
 		if err != nil {
-			ch <- Event{Type: EventError, Error: fmt.Errorf("provider error: %w", err)}
+			ch <- NewErrorEvent(fmt.Errorf("provider error: %w", err))
 			return
 		}
 
@@ -145,7 +175,7 @@ func (l *Loop) run(ctx context.Context, input string, ch chan<- Event) {
 		}
 
 		if len(toolCalls) == 0 {
-			ch <- Event{Type: EventDone, Meta: meta}
+			ch <- NewDoneEvent(meta)
 			return
 		}
 
@@ -155,7 +185,7 @@ func (l *Loop) run(ctx context.Context, input string, ch chan<- Event) {
 		}
 	}
 
-	ch <- Event{Type: EventError, Error: fmt.Errorf("max steps reached (%d)", l.maxSteps)}
+	ch <- NewErrorEvent(fmt.Errorf("max steps reached (%d)", l.maxSteps))
 }
 
 // consumeStream reads all events from the provider stream, forwarding content
@@ -175,10 +205,10 @@ func (l *Loop) consumeStream(ctx context.Context, streamCh <-chan provider.Strea
 		switch event.Type {
 		case provider.EventContentDelta:
 			content.WriteString(event.Content)
-			ch <- Event{Type: EventContentDelta, Content: event.Content}
+			ch <- NewContentEvent(event.Content)
 
 		case provider.EventReasoningDelta:
-			ch <- Event{Type: EventReasoningDelta, Content: event.Content}
+			ch <- NewReasoningEvent(event.Content)
 
 		case provider.EventToolCall:
 			if event.ToolCall != nil {
@@ -189,7 +219,7 @@ func (l *Loop) consumeStream(ctx context.Context, streamCh <-chan provider.Strea
 			meta = event.Meta
 
 		case provider.EventError:
-			ch <- Event{Type: EventError, Error: event.Error}
+			ch <- NewErrorEvent(event.Error)
 			return content.String(), toolCalls, meta
 
 		default:
@@ -202,14 +232,11 @@ func (l *Loop) consumeStream(ctx context.Context, streamCh <-chan provider.Strea
 
 // executeTool runs a single tool call and emits start/end events.
 func (l *Loop) executeTool(ctx context.Context, tc provider.ToolCall, ch chan<- Event) {
-	ch <- Event{
-		Type: EventToolStart,
-		Tool: &ToolEvent{
-			ID:   tc.ID,
-			Name: tc.Name,
-			Args: tc.Args,
-		},
-	}
+	ch <- NewToolStartEvent(&ToolEvent{
+		ID:   tc.ID,
+		Name: tc.Name,
+		Args: tc.Args,
+	})
 
 	t, ok := l.registry.Get(tc.Name)
 	if !ok {
@@ -242,27 +269,21 @@ func (l *Loop) executeTool(ctx context.Context, tc provider.ToolCall, ch chan<- 
 
 	l.session.AddToolResult(tc.ID, output)
 
-	ch <- Event{
-		Type: EventToolEnd,
-		Tool: &ToolEvent{
-			ID:     tc.ID,
-			Name:   tc.Name,
-			Args:   tc.Args,
-			Output: output,
-			Error:  errStr,
-		},
-	}
+	ch <- NewToolEndEvent(&ToolEvent{
+		ID:     tc.ID,
+		Name:   tc.Name,
+		Args:   tc.Args,
+		Output: output,
+		Error:  errStr,
+	})
 }
 
 // emitToolError records a tool error result and emits an EventToolEnd with the error.
 func (l *Loop) emitToolError(tc provider.ToolCall, errMsg string, ch chan<- Event) {
 	l.session.AddToolResult(tc.ID, "error: "+errMsg)
-	ch <- Event{
-		Type: EventToolEnd,
-		Tool: &ToolEvent{
-			ID:    tc.ID,
-			Name:  tc.Name,
-			Error: errMsg,
-		},
-	}
+	ch <- NewToolEndEvent(&ToolEvent{
+		ID:    tc.ID,
+		Name:  tc.Name,
+		Error: errMsg,
+	})
 }

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -16,6 +16,7 @@ type EventType int
 
 const (
 	EventContentDelta EventType = iota
+	EventReasoningDelta
 	EventToolStart
 	EventToolEnd
 	EventDone
@@ -146,6 +147,9 @@ func (l *Loop) consumeStream(ctx context.Context, streamCh <-chan provider.Strea
 		case provider.EventContentDelta:
 			content.WriteString(event.Content)
 			ch <- Event{Type: EventContentDelta, Content: event.Content}
+
+		case provider.EventReasoningDelta:
+			ch <- Event{Type: EventReasoningDelta, Content: event.Content}
 
 		case provider.EventToolCall:
 			if event.ToolCall != nil {

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -166,7 +166,7 @@ func (l *Loop) consumeStream(ctx context.Context, streamCh <-chan provider.Strea
 			return content.String(), toolCalls, meta
 
 		default:
-			store.LogError(fmt.Sprintf("loop: unknown provider event type %d", event.Type), nil)
+			store.LogErrorf("loop: unknown provider event type %d", event.Type)
 		}
 	}
 

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -43,6 +43,33 @@ type Event struct {
 	Error   error // for EventError
 }
 
+// Valid checks that the Event has a recognized type and required fields.
+func (e Event) Valid() error {
+	switch e.Type {
+	case EventContentDelta:
+		// Content may be empty
+	case EventReasoningDelta:
+		// Content may be empty
+	case EventToolStart:
+		if e.Tool == nil {
+			return fmt.Errorf("tool start event missing Tool")
+		}
+	case EventToolEnd:
+		if e.Tool == nil {
+			return fmt.Errorf("tool end event missing Tool")
+		}
+	case EventDone:
+		// No required fields
+	case EventError:
+		if e.Error == nil {
+			return fmt.Errorf("error event missing Error")
+		}
+	default:
+		return fmt.Errorf("unknown event type: %d", e.Type)
+	}
+	return nil
+}
+
 // Loop orchestrates the agent's prompt-stream-tool cycle.
 type Loop struct {
 	provider provider.Provider

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -746,3 +746,56 @@ func TestEvent_Valid_UnknownType(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown event type")
 }
+
+// --- Constructor tests ---
+
+func TestNewContentEvent(t *testing.T) {
+	e := NewContentEvent("hello")
+	assert.Equal(t, EventContentDelta, e.Type)
+	assert.Equal(t, "hello", e.Content)
+	assert.NoError(t, e.Valid())
+}
+
+func TestNewReasoningEvent(t *testing.T) {
+	e := NewReasoningEvent("thinking")
+	assert.Equal(t, EventReasoningDelta, e.Type)
+	assert.Equal(t, "thinking", e.Content)
+	assert.NoError(t, e.Valid())
+}
+
+func TestNewToolStartEvent(t *testing.T) {
+	te := &ToolEvent{ID: "1", Name: "bash"}
+	e := NewToolStartEvent(te)
+	assert.Equal(t, EventToolStart, e.Type)
+	assert.Equal(t, te, e.Tool)
+	assert.NoError(t, e.Valid())
+}
+
+func TestNewToolEndEvent(t *testing.T) {
+	te := &ToolEvent{ID: "1", Name: "bash", Output: "ok"}
+	e := NewToolEndEvent(te)
+	assert.Equal(t, EventToolEnd, e.Type)
+	assert.Equal(t, te, e.Tool)
+	assert.NoError(t, e.Valid())
+}
+
+func TestNewDoneEvent(t *testing.T) {
+	e := NewDoneEvent(nil)
+	assert.Equal(t, EventDone, e.Type)
+	assert.NoError(t, e.Valid())
+}
+
+func TestNewDoneEvent_WithMeta(t *testing.T) {
+	meta := &provider.Metadata{InputTokens: 10, OutputTokens: 5}
+	e := NewDoneEvent(meta)
+	assert.Equal(t, EventDone, e.Type)
+	assert.Equal(t, meta, e.Meta)
+	assert.NoError(t, e.Valid())
+}
+
+func TestNewErrorEvent(t *testing.T) {
+	e := NewErrorEvent(fmt.Errorf("fail"))
+	assert.Equal(t, EventError, e.Type)
+	assert.EqualError(t, e.Error, "fail")
+	assert.NoError(t, e.Valid())
+}

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -654,3 +654,95 @@ func TestLoop_UnknownTool(t *testing.T) {
 	}
 	assert.Contains(t, toolEndError, "unknown tool")
 }
+
+// --- Event.Valid tests ---
+
+func TestLoop_EmptyReasoningDelta_StillEmitted(t *testing.T) {
+	p := &mockProvider{
+		responses: []mockResponse{
+			{events: []provider.StreamEvent{
+				{Type: provider.EventReasoningDelta, Content: ""},
+				{Type: provider.EventContentDelta, Content: "answer"},
+				{Type: provider.EventFinish, Meta: &provider.Metadata{
+					InputTokens: 10, OutputTokens: 5, FinishReason: "stop",
+				}},
+			}},
+		},
+	}
+
+	reg := newTestRegistry()
+	sess := session.New("/tmp")
+	loop := NewLoop(p, reg, sess, BuildAgent(), 10)
+
+	events := collectEvents(loop.Run(context.Background(), "test"))
+
+	var gotContent, gotDone bool
+	for _, e := range events {
+		if e.Type == EventContentDelta {
+			gotContent = true
+		}
+		if e.Type == EventDone {
+			gotDone = true
+		}
+	}
+	assert.True(t, gotContent, "content delta should still be emitted after empty reasoning")
+	assert.True(t, gotDone, "loop should complete normally")
+}
+
+func TestEvent_Valid_ContentDelta(t *testing.T) {
+	e := Event{Type: EventContentDelta, Content: "hello"}
+	assert.NoError(t, e.Valid())
+}
+
+func TestEvent_Valid_ReasoningDelta(t *testing.T) {
+	e := Event{Type: EventReasoningDelta, Content: "thinking"}
+	assert.NoError(t, e.Valid())
+}
+
+func TestEvent_Valid_ToolStart(t *testing.T) {
+	e := Event{Type: EventToolStart, Tool: &ToolEvent{ID: "1", Name: "bash"}}
+	assert.NoError(t, e.Valid())
+}
+
+func TestEvent_Valid_ToolStart_MissingTool(t *testing.T) {
+	e := Event{Type: EventToolStart}
+	err := e.Valid()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing Tool")
+}
+
+func TestEvent_Valid_ToolEnd(t *testing.T) {
+	e := Event{Type: EventToolEnd, Tool: &ToolEvent{ID: "1", Name: "bash", Output: "ok"}}
+	assert.NoError(t, e.Valid())
+}
+
+func TestEvent_Valid_ToolEnd_MissingTool(t *testing.T) {
+	e := Event{Type: EventToolEnd}
+	err := e.Valid()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing Tool")
+}
+
+func TestEvent_Valid_Done(t *testing.T) {
+	e := Event{Type: EventDone}
+	assert.NoError(t, e.Valid())
+}
+
+func TestEvent_Valid_Error(t *testing.T) {
+	e := Event{Type: EventError, Error: fmt.Errorf("fail")}
+	assert.NoError(t, e.Valid())
+}
+
+func TestEvent_Valid_Error_MissingError(t *testing.T) {
+	e := Event{Type: EventError}
+	err := e.Valid()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing Error")
+}
+
+func TestEvent_Valid_UnknownType(t *testing.T) {
+	e := Event{Type: EventType(99)}
+	err := e.Valid()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown event type")
+}

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -459,6 +459,102 @@ func TestLoop_CancelMidStream_DiscardsPartialToolCalls(t *testing.T) {
 	assert.False(t, toolExecuted, "tool should NOT be executed when context is cancelled mid-stream")
 }
 
+func TestLoop_ReasoningDeltaEmitted(t *testing.T) {
+	p := &mockProvider{
+		responses: []mockResponse{
+			{events: []provider.StreamEvent{
+				{Type: provider.EventReasoningDelta, Content: "Let me think..."},
+				{Type: provider.EventContentDelta, Content: "Answer"},
+				{Type: provider.EventFinish, Meta: &provider.Metadata{
+					InputTokens: 10, OutputTokens: 5, FinishReason: "stop",
+				}},
+			}},
+		},
+	}
+
+	reg := newTestRegistry()
+	sess := session.New("/tmp")
+	loop := NewLoop(p, reg, sess, BuildAgent(), 10)
+
+	events := collectEvents(loop.Run(context.Background(), "think"))
+
+	var reasoning, content string
+	var gotDone bool
+	for _, e := range events {
+		switch e.Type {
+		case EventReasoningDelta:
+			reasoning += e.Content
+		case EventContentDelta:
+			content += e.Content
+		case EventDone:
+			gotDone = true
+		}
+	}
+
+	assert.Equal(t, "Let me think...", reasoning)
+	assert.Equal(t, "Answer", content)
+	assert.True(t, gotDone)
+}
+
+func TestLoop_ReasoningDelta_NotPersisted(t *testing.T) {
+	p := &mockProvider{
+		responses: []mockResponse{
+			{events: []provider.StreamEvent{
+				{Type: provider.EventReasoningDelta, Content: "secret thoughts"},
+				{Type: provider.EventContentDelta, Content: "visible answer"},
+				{Type: provider.EventFinish, Meta: &provider.Metadata{
+					InputTokens: 10, OutputTokens: 5, FinishReason: "stop",
+				}},
+			}},
+		},
+	}
+
+	reg := newTestRegistry()
+	sess := session.New("/tmp")
+	loop := NewLoop(p, reg, sess, BuildAgent(), 10)
+
+	_ = collectEvents(loop.Run(context.Background(), "think"))
+
+	// Session should only have user + assistant with content (no reasoning)
+	records := sess.Records()
+	assert.Len(t, records, 2)
+	assert.Equal(t, "visible answer", records[1].Message.Content)
+	// Content should NOT include reasoning text
+	assert.NotContains(t, records[1].Message.Content, "secret thoughts")
+}
+
+func TestLoop_InterleavedReasoningAndContent(t *testing.T) {
+	p := &mockProvider{
+		responses: []mockResponse{
+			{events: []provider.StreamEvent{
+				{Type: provider.EventReasoningDelta, Content: "thinking "},
+				{Type: provider.EventReasoningDelta, Content: "more"},
+				{Type: provider.EventContentDelta, Content: "response "},
+				{Type: provider.EventContentDelta, Content: "text"},
+				{Type: provider.EventFinish, Meta: &provider.Metadata{
+					InputTokens: 10, OutputTokens: 5, FinishReason: "stop",
+				}},
+			}},
+		},
+	}
+
+	reg := newTestRegistry()
+	sess := session.New("/tmp")
+	loop := NewLoop(p, reg, sess, BuildAgent(), 10)
+
+	events := collectEvents(loop.Run(context.Background(), "multi"))
+
+	var types []EventType
+	for _, e := range events {
+		types = append(types, e.Type)
+	}
+
+	// Should see reasoning deltas before content deltas
+	assert.Contains(t, types, EventReasoningDelta)
+	assert.Contains(t, types, EventContentDelta)
+	assert.Contains(t, types, EventDone)
+}
+
 func TestLoop_UnknownTool(t *testing.T) {
 	p := &mockProvider{
 		responses: []mockResponse{

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -459,6 +459,37 @@ func TestLoop_CancelMidStream_DiscardsPartialToolCalls(t *testing.T) {
 	assert.False(t, toolExecuted, "tool should NOT be executed when context is cancelled mid-stream")
 }
 
+func TestLoop_CancelDuringReasoningStream_GracefulTermination(t *testing.T) {
+	p := &mockProvider{
+		responses: []mockResponse{
+			{events: []provider.StreamEvent{
+				{Type: provider.EventReasoningDelta, Content: "thinking hard"},
+				{Type: provider.EventContentDelta, Content: "answer"},
+				{Type: provider.EventFinish, Meta: &provider.Metadata{
+					InputTokens: 10, OutputTokens: 5, FinishReason: "stop",
+				}},
+			}},
+		},
+	}
+
+	reg := newTestRegistry()
+	sess := session.New("/tmp")
+	loop := NewLoop(p, reg, sess, BuildAgent(), 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	events := collectEvents(loop.Run(ctx, "cancel during reasoning"))
+
+	var hasError bool
+	for _, e := range events {
+		if e.Type == EventError {
+			hasError = true
+		}
+	}
+	assert.True(t, hasError, "should emit error when cancelled during reasoning stream")
+}
+
 func TestLoop_ReasoningDeltaEmitted(t *testing.T) {
 	p := &mockProvider{
 		responses: []mockResponse{
@@ -553,6 +584,40 @@ func TestLoop_InterleavedReasoningAndContent(t *testing.T) {
 	assert.Contains(t, types, EventReasoningDelta)
 	assert.Contains(t, types, EventContentDelta)
 	assert.Contains(t, types, EventDone)
+}
+
+func TestLoop_UnknownProviderEventType_GracefullyIgnored(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	p := &mockProvider{
+		responses: []mockResponse{
+			{events: []provider.StreamEvent{
+				{Type: provider.EventContentDelta, Content: "hello"},
+				{Type: provider.EventType(99)}, // unknown event type
+				{Type: provider.EventFinish, Meta: &provider.Metadata{
+					InputTokens: 10, OutputTokens: 5, FinishReason: "stop",
+				}},
+			}},
+		},
+	}
+
+	reg := newTestRegistry()
+	sess := session.New("/tmp")
+	loop := NewLoop(p, reg, sess, BuildAgent(), 10)
+
+	events := collectEvents(loop.Run(context.Background(), "test"))
+
+	var gotContent bool
+	var gotDone bool
+	for _, e := range events {
+		if e.Type == EventContentDelta {
+			gotContent = true
+		}
+		if e.Type == EventDone {
+			gotDone = true
+		}
+	}
+	assert.True(t, gotContent, "content delta should still be emitted")
+	assert.True(t, gotDone, "loop should complete normally after unknown event")
 }
 
 func TestLoop_UnknownTool(t *testing.T) {

--- a/internal/client/openrouter.go
+++ b/internal/client/openrouter.go
@@ -307,7 +307,7 @@ func (c *OpenRouter) streamResponse(ctx context.Context, resp *http.Response, ch
 			case reasoningTypeEncrypted:
 				text = "[REDACTED]"
 			default:
-				store.LogError("unknown reasoning detail type: "+rd.Type, nil)
+				store.LogErrorf("unknown reasoning detail type %q from model %s", rd.Type, requestModel)
 				continue
 			}
 			if text != "" {

--- a/internal/client/openrouter.go
+++ b/internal/client/openrouter.go
@@ -296,6 +296,26 @@ func (c *OpenRouter) streamResponse(ctx context.Context, resp *http.Response, ch
 			}
 		}
 
+		// Reasoning deltas
+		for _, rd := range choice.Delta.ReasoningDetails {
+			var text string
+			switch rd.Type {
+			case reasoningTypeText:
+				text = rd.Text
+			case reasoningTypeSummary:
+				text = rd.Summary
+			case reasoningTypeEncrypted:
+				text = "[REDACTED]"
+			default:
+				continue
+			}
+			if text != "" {
+				if !send(provider.NewReasoningDelta(text)) {
+					return
+				}
+			}
+		}
+
 		// Tool call deltas — accumulate fragments
 		for _, tcDelta := range choice.Delta.ToolCalls {
 			acc, exists := toolCalls[tcDelta.Index]
@@ -420,8 +440,23 @@ type apiChoice struct {
 }
 
 type apiDelta struct {
-	Content   string             `json:"content,omitempty"`
-	ToolCalls []apiToolCallDelta `json:"tool_calls,omitempty"`
+	Content          string               `json:"content,omitempty"`
+	ToolCalls        []apiToolCallDelta   `json:"tool_calls,omitempty"`
+	ReasoningDetails []apiReasoningDetail `json:"reasoning_details,omitempty"`
+}
+
+// Reasoning detail type constants from the OpenRouter streaming API.
+const (
+	reasoningTypeText      = "reasoning.text"
+	reasoningTypeSummary   = "reasoning.summary"
+	reasoningTypeEncrypted = "reasoning.encrypted"
+)
+
+type apiReasoningDetail struct {
+	Type    string `json:"type"`
+	Text    string `json:"text,omitempty"`    // for reasoningTypeText
+	Summary string `json:"summary,omitempty"` // for reasoningTypeSummary
+	Data    string `json:"data,omitempty"`    // for reasoningTypeEncrypted
 }
 
 type apiToolCallDelta struct {

--- a/internal/client/openrouter.go
+++ b/internal/client/openrouter.go
@@ -298,15 +298,8 @@ func (c *OpenRouter) streamResponse(ctx context.Context, resp *http.Response, ch
 
 		// Reasoning deltas
 		for _, rd := range choice.Delta.ReasoningDetails {
-			var text string
-			switch rd.Type {
-			case reasoningTypeText:
-				text = rd.Text
-			case reasoningTypeSummary:
-				text = rd.Summary
-			case reasoningTypeEncrypted:
-				text = "[REDACTED]"
-			default:
+			text, known := rd.content()
+			if !known {
 				store.LogErrorf("unknown reasoning detail type %q from model %s", rd.Type, requestModel)
 				continue
 			}
@@ -453,11 +446,31 @@ const (
 	reasoningTypeEncrypted = "reasoning.encrypted"
 )
 
+// apiReasoningDetail represents a single reasoning detail from OpenRouter's
+// streaming API. The Type field determines which content field is populated:
+//   - "reasoning.text": raw thinking text in Text field
+//   - "reasoning.summary": summarized reasoning in Summary field
+//   - "reasoning.encrypted": encrypted reasoning blob in Data field (shown as [REDACTED])
 type apiReasoningDetail struct {
 	Type    string `json:"type"`
 	Text    string `json:"text,omitempty"`    // for reasoningTypeText
 	Summary string `json:"summary,omitempty"` // for reasoningTypeSummary
 	Data    string `json:"data,omitempty"`    // for reasoningTypeEncrypted
+}
+
+// content returns the user-facing text for this reasoning detail based on its
+// type. The bool is false for unrecognized types (which the caller should log).
+func (r apiReasoningDetail) content() (string, bool) {
+	switch r.Type {
+	case reasoningTypeText:
+		return r.Text, true
+	case reasoningTypeSummary:
+		return r.Summary, true
+	case reasoningTypeEncrypted:
+		return "[REDACTED]", true
+	default:
+		return "", false
+	}
 }
 
 type apiToolCallDelta struct {

--- a/internal/client/openrouter.go
+++ b/internal/client/openrouter.go
@@ -307,6 +307,7 @@ func (c *OpenRouter) streamResponse(ctx context.Context, resp *http.Response, ch
 			case reasoningTypeEncrypted:
 				text = "[REDACTED]"
 			default:
+				store.LogError("unknown reasoning detail type: "+rd.Type, nil)
 				continue
 			}
 			if text != "" {

--- a/internal/client/openrouter_test.go
+++ b/internal/client/openrouter_test.go
@@ -785,6 +785,231 @@ func TestStreamResponse_IncompleteToolCall(t *testing.T) {
 	}
 }
 
+// reasoningChunk builds a streaming chunk with reasoning_details.
+func reasoningChunk(details ...map[string]any) string {
+	delta := map[string]any{
+		"reasoning_details": details,
+	}
+
+	choice := map[string]any{
+		"index": 0,
+		"delta": delta,
+	}
+
+	resp := map[string]any{
+		"id":      "gen-123",
+		"model":   "deepseek/deepseek-r1",
+		"choices": []any{choice},
+	}
+
+	b, _ := json.Marshal(resp)
+	return string(b)
+}
+
+// mixedReasoningChunk builds a chunk with both content and reasoning_details.
+func mixedReasoningChunk(content string, details ...map[string]any) string {
+	delta := map[string]any{
+		"content":           content,
+		"reasoning_details": details,
+	}
+
+	choice := map[string]any{
+		"index": 0,
+		"delta": delta,
+	}
+
+	resp := map[string]any{
+		"id":      "gen-123",
+		"model":   "deepseek/deepseek-r1",
+		"choices": []any{choice},
+	}
+
+	b, _ := json.Marshal(resp)
+	return string(b)
+}
+
+func TestOpenRouter_ParsesReasoningText(t *testing.T) {
+	body := sseResponse(
+		reasoningChunk(map[string]any{"type": "reasoning.text", "text": "Let me think"}),
+		chatChunk("answer", ""),
+		chatChunkWithUsage("stop", 10, 5),
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	c := NewOpenRouter("test-key", "test-model")
+	c.baseURL = srv.URL
+
+	ch, err := c.Chat(context.Background(), []provider.Message{
+		{Role: "user", Content: "hi"},
+	}, nil)
+	require.NoError(t, err)
+
+	var reasoning, content strings.Builder
+	for e := range ch {
+		switch e.Type {
+		case provider.EventReasoningDelta:
+			reasoning.WriteString(e.Content)
+		case provider.EventContentDelta:
+			content.WriteString(e.Content)
+		}
+	}
+
+	assert.Equal(t, "Let me think", reasoning.String())
+	assert.Equal(t, "answer", content.String())
+}
+
+func TestOpenRouter_ParsesReasoningSummary(t *testing.T) {
+	body := sseResponse(
+		reasoningChunk(map[string]any{"type": "reasoning.summary", "summary": "Summary text"}),
+		chatChunkWithUsage("stop", 10, 5),
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	c := NewOpenRouter("test-key", "test-model")
+	c.baseURL = srv.URL
+
+	ch, err := c.Chat(context.Background(), []provider.Message{
+		{Role: "user", Content: "hi"},
+	}, nil)
+	require.NoError(t, err)
+
+	var reasoning strings.Builder
+	for e := range ch {
+		if e.Type == provider.EventReasoningDelta {
+			reasoning.WriteString(e.Content)
+		}
+	}
+
+	assert.Equal(t, "Summary text", reasoning.String())
+}
+
+func TestOpenRouter_ParsesReasoningEncrypted(t *testing.T) {
+	body := sseResponse(
+		reasoningChunk(map[string]any{"type": "reasoning.encrypted", "data": "abc123"}),
+		chatChunkWithUsage("stop", 10, 5),
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	c := NewOpenRouter("test-key", "test-model")
+	c.baseURL = srv.URL
+
+	ch, err := c.Chat(context.Background(), []provider.Message{
+		{Role: "user", Content: "hi"},
+	}, nil)
+	require.NoError(t, err)
+
+	var reasoning strings.Builder
+	for e := range ch {
+		if e.Type == provider.EventReasoningDelta {
+			reasoning.WriteString(e.Content)
+		}
+	}
+
+	assert.Equal(t, "[REDACTED]", reasoning.String())
+}
+
+func TestOpenRouter_ParsesMixedContentAndReasoning(t *testing.T) {
+	body := sseResponse(
+		mixedReasoningChunk("text", map[string]any{"type": "reasoning.text", "text": "think"}),
+		chatChunkWithUsage("stop", 10, 5),
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	c := NewOpenRouter("test-key", "test-model")
+	c.baseURL = srv.URL
+
+	ch, err := c.Chat(context.Background(), []provider.Message{
+		{Role: "user", Content: "hi"},
+	}, nil)
+	require.NoError(t, err)
+
+	var reasoning, content strings.Builder
+	for e := range ch {
+		switch e.Type {
+		case provider.EventReasoningDelta:
+			reasoning.WriteString(e.Content)
+		case provider.EventContentDelta:
+			content.WriteString(e.Content)
+		}
+	}
+
+	assert.Equal(t, "think", reasoning.String())
+	assert.Equal(t, "text", content.String())
+}
+
+func TestOpenRouter_ParsesEmptyReasoningDetails_Skip(t *testing.T) {
+	body := sseResponse(
+		reasoningChunk(), // empty reasoning_details array
+		chatChunk("content", ""),
+		chatChunkWithUsage("stop", 10, 5),
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	c := NewOpenRouter("test-key", "test-model")
+	c.baseURL = srv.URL
+
+	ch, err := c.Chat(context.Background(), []provider.Message{
+		{Role: "user", Content: "hi"},
+	}, nil)
+	require.NoError(t, err)
+
+	for e := range ch {
+		assert.NotEqual(t, provider.EventReasoningDelta, e.Type,
+			"empty reasoning details should not produce events")
+	}
+}
+
+func TestOpenRouter_ParsesUnknownReasoningType_Skip(t *testing.T) {
+	body := sseResponse(
+		reasoningChunk(map[string]any{"type": "reasoning.future_type", "text": "unknown"}),
+		chatChunkWithUsage("stop", 10, 5),
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	c := NewOpenRouter("test-key", "test-model")
+	c.baseURL = srv.URL
+
+	ch, err := c.Chat(context.Background(), []provider.Message{
+		{Role: "user", Content: "hi"},
+	}, nil)
+	require.NoError(t, err)
+
+	for e := range ch {
+		assert.NotEqual(t, provider.EventReasoningDelta, e.Type,
+			"unknown reasoning type should not produce events")
+	}
+}
+
 func TestOpenRouter_ReasoningEffortEmpty_OmitsField(t *testing.T) {
 	c := NewOpenRouter("key", "model")
 	// No SetReasoningEffort call — effort is empty

--- a/internal/client/openrouter_test.go
+++ b/internal/client/openrouter_test.go
@@ -1010,6 +1010,68 @@ func TestOpenRouter_ParsesUnknownReasoningType_Skip(t *testing.T) {
 	}
 }
 
+func TestOpenRouter_ParsesMultipleReasoningDetailsInSingleChunk(t *testing.T) {
+	body := sseResponse(
+		reasoningChunk(
+			map[string]any{"type": "reasoning.text", "text": "thought A"},
+			map[string]any{"type": "reasoning.summary", "summary": "summary B"},
+		),
+		chatChunkWithUsage("stop", 10, 5),
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	c := NewOpenRouter("test-key", "test-model")
+	c.baseURL = srv.URL
+
+	ch, err := c.Chat(context.Background(), []provider.Message{
+		{Role: "user", Content: "hi"},
+	}, nil)
+	require.NoError(t, err)
+
+	var reasoningEvents []string
+	for e := range ch {
+		if e.Type == provider.EventReasoningDelta {
+			reasoningEvents = append(reasoningEvents, e.Content)
+		}
+	}
+
+	assert.Len(t, reasoningEvents, 2, "both reasoning details should produce separate events")
+	assert.Equal(t, "thought A", reasoningEvents[0])
+	assert.Equal(t, "summary B", reasoningEvents[1])
+}
+
+func TestOpenRouter_ParsesReasoningWithEmptyText_Skipped(t *testing.T) {
+	body := sseResponse(
+		reasoningChunk(map[string]any{"type": "reasoning.text", "text": ""}),
+		chatChunk("content", ""),
+		chatChunkWithUsage("stop", 10, 5),
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, body)
+	}))
+	defer srv.Close()
+
+	c := NewOpenRouter("test-key", "test-model")
+	c.baseURL = srv.URL
+
+	ch, err := c.Chat(context.Background(), []provider.Message{
+		{Role: "user", Content: "hi"},
+	}, nil)
+	require.NoError(t, err)
+
+	for e := range ch {
+		assert.NotEqual(t, provider.EventReasoningDelta, e.Type,
+			"empty text reasoning should not produce events")
+	}
+}
+
 func TestOpenRouter_ReasoningEffortEmpty_OmitsField(t *testing.T) {
 	c := NewOpenRouter("key", "model")
 	// No SetReasoningEffort call — effort is empty

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -103,7 +103,7 @@ const (
 	EventToolCall
 	EventFinish
 	EventError
-	EventReasoningDelta // Appended last to preserve existing ordinals for backward compat
+	EventReasoningDelta // Added after original constants to preserve their ordinals (0-3)
 )
 
 // StreamEvent is a single event in a streaming LLM response.
@@ -119,9 +119,9 @@ type StreamEvent struct {
 func (e StreamEvent) Valid() error {
 	switch e.Type {
 	case EventContentDelta:
-		// Content may be empty (e.g. whitespace-only delta)
+		// Content may be empty (whitespace-only deltas are valid in SSE streams)
 	case EventReasoningDelta:
-		// Content may be empty (e.g. whitespace-only delta)
+		// Content may be empty (whitespace-only deltas are valid in SSE streams)
 	case EventToolCall:
 		if e.ToolCall == nil {
 			return fmt.Errorf("tool call event missing ToolCall")

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -103,6 +103,7 @@ const (
 	EventToolCall
 	EventFinish
 	EventError
+	EventReasoningDelta
 )
 
 // StreamEvent is a single event in a streaming LLM response.
@@ -118,6 +119,8 @@ type StreamEvent struct {
 func (e StreamEvent) Valid() error {
 	switch e.Type {
 	case EventContentDelta:
+		// Content may be empty (e.g. whitespace-only delta)
+	case EventReasoningDelta:
 		// Content may be empty (e.g. whitespace-only delta)
 	case EventToolCall:
 		if e.ToolCall == nil {
@@ -140,6 +143,11 @@ func (e StreamEvent) Valid() error {
 // NewContentDelta creates a content delta event.
 func NewContentDelta(content string) StreamEvent {
 	return StreamEvent{Type: EventContentDelta, Content: content}
+}
+
+// NewReasoningDelta creates a reasoning delta event.
+func NewReasoningDelta(content string) StreamEvent {
+	return StreamEvent{Type: EventReasoningDelta, Content: content}
 }
 
 // NewToolCallEvent creates a tool call event.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -103,7 +103,7 @@ const (
 	EventToolCall
 	EventFinish
 	EventError
-	EventReasoningDelta
+	EventReasoningDelta // Appended last to preserve existing ordinals for backward compat
 )
 
 // StreamEvent is a single event in a streaming LLM response.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -104,6 +104,7 @@ func TestEventType_Values(t *testing.T) {
 	assert.Equal(t, EventType(1), EventToolCall)
 	assert.Equal(t, EventType(2), EventFinish)
 	assert.Equal(t, EventType(3), EventError)
+	assert.Equal(t, EventType(4), EventReasoningDelta)
 }
 
 func TestModelInfo_ProviderName_ExtractsFromID(t *testing.T) {
@@ -326,6 +327,20 @@ func TestStreamEvent_Constructors(t *testing.T) {
 	e4 := NewErrorEvent(fmt.Errorf("fail"))
 	assert.Equal(t, EventError, e4.Type)
 	assert.Equal(t, "fail", e4.Error.Error())
+
+	e5 := NewReasoningDelta("thinking")
+	assert.Equal(t, EventReasoningDelta, e5.Type)
+	assert.Equal(t, "thinking", e5.Content)
+}
+
+func TestStreamEvent_Valid_ReasoningDelta(t *testing.T) {
+	e := StreamEvent{Type: EventReasoningDelta, Content: "thought"}
+	assert.NoError(t, e.Valid())
+}
+
+func TestStreamEvent_Valid_ReasoningDelta_Empty(t *testing.T) {
+	e := StreamEvent{Type: EventReasoningDelta}
+	assert.NoError(t, e.Valid(), "empty reasoning delta is valid")
 }
 
 func TestParseRole_ValidRoles(t *testing.T) {

--- a/internal/store/log.go
+++ b/internal/store/log.go
@@ -7,6 +7,11 @@ import (
 	"time"
 )
 
+// LogErrorf appends a formatted error line to the error log (no underlying error).
+func LogErrorf(format string, args ...any) {
+	LogError(fmt.Sprintf(format, args...), nil)
+}
+
 // LogError appends a timestamped error line to the error log.
 // Falls back to stderr if the log file cannot be opened.
 func LogError(msg string, err error) {

--- a/internal/store/log_test.go
+++ b/internal/store/log_test.go
@@ -48,6 +48,18 @@ func TestLogError_CreatesStateDir(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestLogErrorf_FormatsMessage(t *testing.T) {
+	testDir(t)
+	LogErrorf("unknown type %q in %s", "foo", "render")
+
+	path := filepath.Join(StateDir(), "errors.log")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, `unknown type "foo" in render`)
+	assert.Contains(t, content, "<nil>")
+}
+
 func TestLogError_FallsBackToStderr(t *testing.T) {
 	dir := testDir(t)
 	// Make the state dir unwritable so file logging fails.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -89,9 +89,6 @@ type App struct {
 	toasts           components.ToastManager
 	shellMode        bool
 	cmdRegistry      *CommandRegistry
-	showDetails      bool
-	showThinking     bool
-	showTimestamps   bool
 
 	// Leader key prefix
 	leaderPending bool

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -192,9 +192,9 @@ func (a *App) initRegistry() {
 		Title: "Details", Description: "Toggle tool detail display",
 		Execute: true,
 		Handler: func(a *App) tea.Cmd {
-			a.showDetails = !a.showDetails
+			a.chat.SetShowDetails(!a.chat.ShowDetails())
 			state := "shown"
-			if !a.showDetails {
+			if !a.chat.ShowDetails() {
 				state = "hidden"
 			}
 			return a.ShowToast(fmt.Sprintf("Tool details %s", state), components.ToastInfo)
@@ -334,9 +334,9 @@ func (a *App) initRegistry() {
 		Title: "Thinking", Description: "Toggle thinking block display",
 		Execute: true,
 		Handler: func(a *App) tea.Cmd {
-			a.showThinking = !a.showThinking
+			a.chat.SetShowThinking(!a.chat.ShowThinking())
 			state := "shown"
-			if !a.showThinking {
+			if !a.chat.ShowThinking() {
 				state = "hidden"
 			}
 			return a.ShowToast(fmt.Sprintf("Thinking blocks %s", state), components.ToastInfo)
@@ -361,9 +361,9 @@ func (a *App) initRegistry() {
 		Title: "Timestamps", Description: "Toggle message timestamps",
 		Execute: true,
 		Handler: func(a *App) tea.Cmd {
-			a.showTimestamps = !a.showTimestamps
+			a.chat.SetShowTimestamps(!a.chat.ShowTimestamps())
 			state := "shown"
-			if !a.showTimestamps {
+			if !a.chat.ShowTimestamps() {
 				state = "hidden"
 			}
 			return a.ShowToast(fmt.Sprintf("Timestamps %s", state), components.ToastInfo)
@@ -461,6 +461,20 @@ func (a *App) initRegistry() {
 			a.stashDialog.open = true
 			a.stashDialog.selected = 0
 			return nil
+		},
+	})
+
+	r.Register(Command{
+		Name: "conceal", Category: CategoryView,
+		Title: "Conceal", Description: "Toggle code block visibility",
+		Hidden: true, Execute: true,
+		Handler: func(a *App) tea.Cmd {
+			a.chat.SetShowCodeBlocks(!a.chat.ShowCodeBlocks())
+			state := "shown"
+			if !a.chat.ShowCodeBlocks() {
+				state = "hidden"
+			}
+			return a.ShowToast(fmt.Sprintf("Code blocks %s", state), components.ToastInfo)
 		},
 	})
 

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -173,7 +173,7 @@ func (a *App) initRegistry() {
 			var last string
 			for i := len(entries) - 1; i >= 0; i-- {
 				if entries[i].Role == components.RoleAssistant {
-					last = entries[i].Content
+					last = entries[i].CopyableContent()
 					break
 				}
 			}

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -14,6 +14,15 @@ import (
 	"github.com/stephenbrandon/ripcode/internal/tui/components"
 )
 
+// toggleToast returns a toast command with "X shown" or "X hidden" message.
+func toggleToast(a *App, label string, enabled bool) tea.Cmd {
+	state := "hidden"
+	if enabled {
+		state = "shown"
+	}
+	return a.ShowToast(fmt.Sprintf("%s %s", label, state), components.ToastInfo)
+}
+
 func (a *App) initRegistry() {
 	r := NewCommandRegistry()
 
@@ -193,11 +202,7 @@ func (a *App) initRegistry() {
 		Execute: true,
 		Handler: func(a *App) tea.Cmd {
 			a.chat.SetShowDetails(!a.chat.ShowDetails())
-			state := "shown"
-			if !a.chat.ShowDetails() {
-				state = "hidden"
-			}
-			return a.ShowToast(fmt.Sprintf("Tool details %s", state), components.ToastInfo)
+			return toggleToast(a, "Tool details", a.chat.ShowDetails())
 		},
 	})
 
@@ -335,11 +340,7 @@ func (a *App) initRegistry() {
 		Execute: true,
 		Handler: func(a *App) tea.Cmd {
 			a.chat.SetShowThinking(!a.chat.ShowThinking())
-			state := "shown"
-			if !a.chat.ShowThinking() {
-				state = "hidden"
-			}
-			return a.ShowToast(fmt.Sprintf("Thinking blocks %s", state), components.ToastInfo)
+			return toggleToast(a, "Thinking blocks", a.chat.ShowThinking())
 		},
 	})
 
@@ -362,11 +363,7 @@ func (a *App) initRegistry() {
 		Execute: true,
 		Handler: func(a *App) tea.Cmd {
 			a.chat.SetShowTimestamps(!a.chat.ShowTimestamps())
-			state := "shown"
-			if !a.chat.ShowTimestamps() {
-				state = "hidden"
-			}
-			return a.ShowToast(fmt.Sprintf("Timestamps %s", state), components.ToastInfo)
+			return toggleToast(a, "Timestamps", a.chat.ShowTimestamps())
 		},
 	})
 
@@ -470,11 +467,7 @@ func (a *App) initRegistry() {
 		Hidden: true, Execute: true,
 		Handler: func(a *App) tea.Cmd {
 			a.chat.SetShowCodeBlocks(!a.chat.ShowCodeBlocks())
-			state := "shown"
-			if !a.chat.ShowCodeBlocks() {
-				state = "hidden"
-			}
-			return a.ShowToast(fmt.Sprintf("Code blocks %s", state), components.ToastInfo)
+			return toggleToast(a, "Code blocks", a.chat.ShowCodeBlocks())
 		},
 	})
 

--- a/internal/tui/components/chat.go
+++ b/internal/tui/components/chat.go
@@ -8,6 +8,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/stephenbrandon/ripcode/internal/store"
 	"github.com/stephenbrandon/ripcode/internal/tui/styles"
 )
 
@@ -152,6 +153,9 @@ func (c *Chat) StreamPart(typ PartType, delta string) {
 	if delta == "" {
 		return
 	}
+	if !typ.Valid() {
+		store.LogError(fmt.Sprintf("chat: StreamPart called with invalid type %q", typ), nil)
+	}
 	if n := len(c.streamingParts); n > 0 && c.streamingParts[n-1].Type == typ {
 		c.streamingParts[n-1].Content += delta
 	} else {
@@ -165,21 +169,25 @@ func (c *Chat) StreamPart(typ PartType, delta string) {
 // If both paths are populated (shouldn't happen in normal use), parts take
 // precedence and legacy streaming is cleared to avoid data ambiguity.
 func (c *Chat) CommitStream() {
+	now := time.Now()
+
 	// Part-based streaming path — takes precedence over legacy
 	if len(c.streamingParts) > 0 {
 		// Single text part — fall back to Content field for backward compat
 		if len(c.streamingParts) == 1 && c.streamingParts[0].Type == PartText {
 			c.entries = append(c.entries, ChatEntry{
-				Role:    RoleAssistant,
-				Content: c.streamingParts[0].Content,
+				Role:      RoleAssistant,
+				Content:   c.streamingParts[0].Content,
+				CreatedAt: now,
 			})
 		} else {
 			parts := make([]MessagePart, len(c.streamingParts))
 			copy(parts, c.streamingParts)
 			c.entries = append(c.entries, ChatEntry{
-				Role:    RoleAssistant,
-				Content: plainTextFromParts(parts),
-				Parts:   parts,
+				Role:      RoleAssistant,
+				Content:   plainTextFromParts(parts),
+				Parts:     parts,
+				CreatedAt: now,
 			})
 		}
 		c.streamingParts = nil
@@ -190,8 +198,9 @@ func (c *Chat) CommitStream() {
 	// Legacy streaming path
 	if c.streaming != "" {
 		c.entries = append(c.entries, ChatEntry{
-			Role:    RoleAssistant,
-			Content: c.streaming,
+			Role:      RoleAssistant,
+			Content:   c.streaming,
+			CreatedAt: now,
 		})
 		c.streaming = ""
 	}
@@ -475,7 +484,10 @@ func (c Chat) renderAssistantParts(parts []MessagePart, t *styles.Theme) []strin
 			for _, line := range strings.Split(wrapped, "\n") {
 				result = append(result, "   "+reasoningStyle.Render(line))
 			}
-		default: // PartText and any future types
+		default: // PartText and any future types — render as text
+			if p.Type != PartText {
+				store.LogError(fmt.Sprintf("chat: unknown part type %q rendered as text", p.Type), nil)
+			}
 			text := p.Content
 			if !c.showCodeBlocks {
 				text, inConcealedBlock = concealCodeBlocksWithState(text, inConcealedBlock)

--- a/internal/tui/components/chat.go
+++ b/internal/tui/components/chat.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -32,6 +33,20 @@ type CompleteMeta struct {
 	Mode     string
 	Model    string
 	Duration time.Duration
+}
+
+// PartType identifies the kind of content in a message part.
+type PartType string
+
+const (
+	PartText      PartType = "text"
+	PartReasoning PartType = "reasoning"
+)
+
+// MessagePart is a single content segment within an assistant message.
+type MessagePart struct {
+	Type    PartType
+	Content string
 }
 
 // ChatEntry represents a single rendered entry in the chat.
@@ -147,8 +162,10 @@ func (c *Chat) StreamPart(typ PartType, delta string) {
 
 // CommitStream finalizes streaming content as an assistant entry.
 // Handles both legacy streaming (single string) and part-based streaming.
+// If both paths are populated (shouldn't happen in normal use), parts take
+// precedence and legacy streaming is cleared to avoid data ambiguity.
 func (c *Chat) CommitStream() {
-	// Part-based streaming path
+	// Part-based streaming path — takes precedence over legacy
 	if len(c.streamingParts) > 0 {
 		// Single text part — fall back to Content field for backward compat
 		if len(c.streamingParts) == 1 && c.streamingParts[0].Type == PartText {
@@ -330,11 +347,12 @@ func (c Chat) View() string {
 	visibleLines := c.height
 
 	maxScroll := max(0, totalLines-visibleLines)
-	if c.scrollPos > maxScroll {
-		c.scrollPos = maxScroll
+	scrollPos := c.scrollPos
+	if scrollPos > maxScroll {
+		scrollPos = maxScroll
 	}
 
-	start := c.scrollPos
+	start := scrollPos
 	end := min(start+visibleLines, totalLines)
 
 	if start >= totalLines {
@@ -445,6 +463,7 @@ func (c Chat) renderAssistantParts(parts []MessagePart, t *styles.Theme) []strin
 	}
 
 	var result []string
+	inConcealedBlock := false
 	for _, p := range parts {
 		switch p.Type {
 		case PartReasoning:
@@ -459,7 +478,7 @@ func (c Chat) renderAssistantParts(parts []MessagePart, t *styles.Theme) []strin
 		default: // PartText and any future types
 			text := p.Content
 			if !c.showCodeBlocks {
-				text = concealCodeBlocks(text)
+				text, inConcealedBlock = concealCodeBlocksWithState(text, inConcealedBlock)
 			}
 			wrapped := wrapText(text, maxWidth)
 			for _, line := range strings.Split(wrapped, "\n") {
@@ -468,7 +487,15 @@ func (c Chat) renderAssistantParts(parts []MessagePart, t *styles.Theme) []strin
 		}
 	}
 	if len(result) == 0 {
-		result = append(result, "   ")
+		// All parts were hidden reasoning — show muted indicator
+		hasReasoning := slices.ContainsFunc(parts, func(p MessagePart) bool {
+			return p.Type == PartReasoning
+		})
+		if hasReasoning && !c.showThinking {
+			result = append(result, "   "+t.TextMutedStyle.Render("[thinking]"))
+		} else {
+			result = append(result, "   ")
+		}
 	}
 	return result
 }
@@ -589,9 +616,15 @@ func (c Chat) renderCompleteEntry(entry ChatEntry, t *styles.Theme) []string {
 // concealCodeBlocks replaces fenced code blocks (``` ... ```) with a placeholder.
 // Inline `code` is not affected. Unclosed blocks are concealed to end of string.
 func concealCodeBlocks(text string) string {
+	out, _ := concealCodeBlocksWithState(text, false)
+	return out
+}
+
+// concealCodeBlocksWithState replaces fenced code blocks while preserving
+// whether concealment is currently inside an unclosed fence.
+func concealCodeBlocksWithState(text string, inBlock bool) (string, bool) {
 	lines := strings.Split(text, "\n")
 	var result []string
-	inBlock := false
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if !inBlock && strings.HasPrefix(trimmed, "```") {
@@ -613,7 +646,7 @@ func concealCodeBlocks(text string) string {
 		}
 		result = append(result, line)
 	}
-	return strings.Join(result, "\n")
+	return strings.Join(result, "\n"), inBlock
 }
 
 // prependTimestamp prepends a 12-hour timestamp prefix to a line if timestamps are enabled

--- a/internal/tui/components/chat.go
+++ b/internal/tui/components/chat.go
@@ -8,6 +8,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stephenbrandon/ripcode/internal/store"
 	"github.com/stephenbrandon/ripcode/internal/tui/styles"
 )
@@ -37,11 +38,13 @@ type CompleteMeta struct {
 }
 
 // PartType identifies the kind of content in a message part.
+// When adding new variants, update Valid() and all switch statements
+// in parts.go and chat.go.
 type PartType string
 
 const (
-	PartText      PartType = "text"
-	PartReasoning PartType = "reasoning"
+	PartText      PartType = "text"      // user-visible assistant response content
+	PartReasoning PartType = "reasoning" // model reasoning/thinking (may be hidden)
 )
 
 // MessagePart is a single content segment within an assistant message.
@@ -130,6 +133,9 @@ func (c Chat) ShowCodeBlocks() bool { return c.showCodeBlocks }
 
 // AddEntry adds a completed message to the chat.
 func (c *Chat) AddEntry(entry ChatEntry) {
+	if entry.CreatedAt.IsZero() {
+		entry.CreatedAt = time.Now()
+	}
 	c.entries = append(c.entries, entry)
 	c.streaming = ""
 	c.scrollToBottom()
@@ -175,8 +181,12 @@ func (c *Chat) StreamPart(typ PartType, delta string) {
 //   - Legacy: StreamContent() accumulates raw deltas (pre-Phase 5 path)
 //   - Parts: StreamPart() accumulates typed content segments (text/reasoning)
 //
+// When using the parts path with a single text-only part, the entry uses only
+// the Content field (not Parts) for backward compatibility with code that
+// expects plain Content-based entries.
+//
 // If both paths are populated (shouldn't happen in normal use), parts take
-// precedence and legacy streaming is cleared to avoid data ambiguity.
+// precedence and legacy streaming is cleared with a warning log.
 func (c *Chat) CommitStream() {
 	now := time.Now()
 
@@ -430,14 +440,20 @@ func (c Chat) renderUserEntry(entry ChatEntry, t *styles.Theme) []string {
 		maxWidth = minContentWidth
 	}
 
-	wrapped := wrapText(entry.Content, maxWidth)
+	tsPrefix := c.timestampPrefix(entry, t)
+	firstLineWidth := maxWidth - lipgloss.Width(tsPrefix)
+	if firstLineWidth < 1 {
+		firstLineWidth = 1
+	}
+
+	wrapped := wrapTextWithFirstLineWidth(entry.Content, firstLineWidth, maxWidth)
 	contentLines := strings.Split(wrapped, "\n")
 
 	result := make([]string, 0, len(contentLines)+1)
 	for i, line := range contentLines {
 		rendered := accentStyle.Render("┃") + " " + line
 		if i == 0 {
-			rendered = c.prependTimestamp(rendered, entry, t)
+			rendered = tsPrefix + rendered
 		}
 		result = append(result, rendered)
 	}
@@ -483,6 +499,8 @@ func (c Chat) renderAssistantEntry(entry ChatEntry, t *styles.Theme) []string {
 }
 
 // renderAssistantParts renders a parts-based assistant message.
+// Unknown PartTypes are logged as errors but rendered as text to preserve
+// content visibility — graceful degradation over data loss.
 func (c Chat) renderAssistantParts(parts []MessagePart, t *styles.Theme) []string {
 	maxWidth := c.contentWidth()
 
@@ -597,7 +615,7 @@ func (c Chat) renderToolEntry(entry ChatEntry, t *styles.Theme) []string {
 		}
 		for _, dl := range strings.Split(entry.Content, "\n") {
 			if lipgloss.Width(dl) > maxW {
-				dl = dl[:maxW]
+				dl = ansi.Truncate(dl, maxW, "")
 			}
 			lines = append(lines, "      "+t.TextMutedStyle.Render(dl))
 		}
@@ -659,7 +677,15 @@ func concealCodeBlocks(text string) string {
 }
 
 // concealCodeBlocksWithState replaces fenced code blocks while preserving
-// whether concealment is currently inside an unclosed fence.
+// whether concealment is currently inside an unclosed fence. This enables
+// processing text across multiple message parts where a code block may
+// start in one part and end in another.
+//
+// State machine:
+//   - inBlock=false: output lines until ``` opens a block
+//   - inBlock=true: skip lines until ``` closes the block
+//   - One-line blocks (```code```) are detected and handled
+//   - Unclosed blocks at end of text remain in inBlock=true state
 func concealCodeBlocksWithState(text string, inBlock bool) (string, bool) {
 	lines := strings.Split(text, "\n")
 	var result []string
@@ -690,11 +716,14 @@ func concealCodeBlocksWithState(text string, inBlock bool) (string, bool) {
 // prependTimestamp prepends a 12-hour timestamp prefix to a line if timestamps are enabled
 // and the entry has a non-zero CreatedAt.
 func (c Chat) prependTimestamp(line string, entry ChatEntry, t *styles.Theme) string {
+	return c.timestampPrefix(entry, t) + line
+}
+
+func (c Chat) timestampPrefix(entry ChatEntry, t *styles.Theme) string {
 	if !c.showTimestamps || entry.CreatedAt.IsZero() {
-		return line
+		return ""
 	}
-	ts := entry.CreatedAt.Format("3:04 PM")
-	return t.TextMutedStyle.Render(ts+"  ") + line
+	return t.TextMutedStyle.Render(entry.CreatedAt.Format("3:04 PM") + "  ")
 }
 
 func (c *Chat) scrollToBottom() {
@@ -715,17 +744,42 @@ func (c Chat) totalLines() int {
 }
 
 func wrapText(text string, width int) string {
+	return wrapTextWithFirstLineWidth(text, width, width)
+}
+
+// wrapTextWithFirstLineWidth wraps text with a custom width for the first
+// rendered line, and a separate width for all subsequent lines.
+func wrapTextWithFirstLineWidth(text string, firstWidth, width int) string {
 	if width <= 0 {
 		return text
 	}
+	if firstWidth < 1 {
+		firstWidth = 1
+	}
+	if firstWidth > width {
+		firstWidth = width
+	}
 
 	var result strings.Builder
+	firstRendered := true
+	appendLine := func(line string) {
+		if result.Len() > 0 {
+			result.WriteByte('\n')
+		}
+		result.WriteString(line)
+		firstRendered = false
+	}
+	currentLimit := func() int {
+		if firstRendered {
+			return firstWidth
+		}
+		return width
+	}
+
 	for _, line := range strings.Split(text, "\n") {
-		if lipgloss.Width(line) <= width {
-			if result.Len() > 0 {
-				result.WriteByte('\n')
-			}
-			result.WriteString(line)
+		limit := currentLimit()
+		if lipgloss.Width(line) <= limit {
+			appendLine(line)
 			continue
 		}
 
@@ -734,21 +788,16 @@ func wrapText(text string, width int) string {
 		for _, word := range words {
 			if currentLine == "" {
 				currentLine = word
-			} else if lipgloss.Width(currentLine+" "+word) <= width {
+			} else if lipgloss.Width(currentLine+" "+word) <= limit {
 				currentLine += " " + word
 			} else {
-				if result.Len() > 0 {
-					result.WriteByte('\n')
-				}
-				result.WriteString(currentLine)
+				appendLine(currentLine)
+				limit = currentLimit()
 				currentLine = word
 			}
 		}
 		if currentLine != "" {
-			if result.Len() > 0 {
-				result.WriteByte('\n')
-			}
-			result.WriteString(currentLine)
+			appendLine(currentLine)
 		}
 	}
 	return result.String()

--- a/internal/tui/components/chat.go
+++ b/internal/tui/components/chat.go
@@ -62,6 +62,10 @@ type ChatEntry struct {
 	Meta       *CompleteMeta // for RoleComplete entries
 }
 
+// minContentWidth is the floor for wrapped content width, preventing
+// degenerate layouts when the terminal is very narrow.
+const minContentWidth = 20
+
 // Chat is a scrollable viewport displaying conversation messages.
 type Chat struct {
 	entries        []ChatEntry
@@ -148,7 +152,9 @@ func (c *Chat) StreamContent(delta string) {
 }
 
 // StreamPart appends a delta to the streaming parts accumulator.
-// If the last part matches the type, the delta is appended; otherwise a new part starts.
+// Consecutive deltas of the same type are merged into one part; a type change
+// starts a new part. Invalid PartTypes are logged but still accumulated
+// (non-blocking) to preserve content visibility during streaming.
 func (c *Chat) StreamPart(typ PartType, delta string) {
 	if delta == "" {
 		return
@@ -165,7 +171,10 @@ func (c *Chat) StreamPart(typ PartType, delta string) {
 }
 
 // CommitStream finalizes streaming content as an assistant entry.
-// Handles both legacy streaming (single string) and part-based streaming.
+// Two streaming paths exist for backward compatibility:
+//   - Legacy: StreamContent() accumulates raw deltas (pre-Phase 5 path)
+//   - Parts: StreamPart() accumulates typed content segments (text/reasoning)
+//
 // If both paths are populated (shouldn't happen in normal use), parts take
 // precedence and legacy streaming is cleared to avoid data ambiguity.
 func (c *Chat) CommitStream() {
@@ -417,8 +426,8 @@ func (c Chat) renderUserEntry(entry ChatEntry, t *styles.Theme) []string {
 	accentStyle := lipgloss.NewStyle().Foreground(modeColor)
 
 	maxWidth := c.width - 4 // ┃ + space + padding
-	if maxWidth < 20 {
-		maxWidth = 20
+	if maxWidth < minContentWidth {
+		maxWidth = minContentWidth
 	}
 
 	wrapped := wrapText(entry.Content, maxWidth)
@@ -436,6 +445,15 @@ func (c Chat) renderUserEntry(entry ChatEntry, t *styles.Theme) []string {
 	return result
 }
 
+// contentWidth returns the maximum content width for assistant messages.
+func (c Chat) contentWidth() int {
+	maxWidth := c.width - 3 // 3-space indent
+	if maxWidth < minContentWidth {
+		return minContentWidth
+	}
+	return maxWidth
+}
+
 // renderAssistantEntry renders assistant messages with 3-space indent.
 func (c Chat) renderAssistantEntry(entry ChatEntry, t *styles.Theme) []string {
 	if len(entry.Parts) > 0 {
@@ -446,11 +464,7 @@ func (c Chat) renderAssistantEntry(entry ChatEntry, t *styles.Theme) []string {
 		return result
 	}
 
-	maxWidth := c.width - 3
-	if maxWidth < 20 {
-		maxWidth = 20
-	}
-
+	maxWidth := c.contentWidth()
 	content := entry.Content
 	if !c.showCodeBlocks {
 		content = concealCodeBlocks(content)
@@ -470,10 +484,7 @@ func (c Chat) renderAssistantEntry(entry ChatEntry, t *styles.Theme) []string {
 
 // renderAssistantParts renders a parts-based assistant message.
 func (c Chat) renderAssistantParts(parts []MessagePart, t *styles.Theme) []string {
-	maxWidth := c.width - 3
-	if maxWidth < 20 {
-		maxWidth = 20
-	}
+	maxWidth := c.contentWidth()
 
 	var result []string
 	inConcealedBlock := false
@@ -581,8 +592,8 @@ func (c Chat) renderToolEntry(entry ChatEntry, t *styles.Theme) []string {
 
 	if c.showDetails && entry.Content != "" && entry.ToolStatus != StatusPending {
 		maxW := c.width - 8
-		if maxW < 20 {
-			maxW = 20
+		if maxW < minContentWidth {
+			maxW = minContentWidth
 		}
 		for _, dl := range strings.Split(entry.Content, "\n") {
 			if lipgloss.Width(dl) > maxW {
@@ -605,8 +616,8 @@ func (c Chat) renderSystemEntry(entry ChatEntry, t *styles.Theme) []string {
 	prefix := t.TextMutedStyle.Render("~") + " "
 
 	maxWidth := c.width - lipgloss.Width(prefix)
-	if maxWidth < 20 {
-		maxWidth = 20
+	if maxWidth < minContentWidth {
+		maxWidth = minContentWidth
 	}
 
 	wrapped := wrapText(entry.Content, maxWidth)

--- a/internal/tui/components/chat.go
+++ b/internal/tui/components/chat.go
@@ -38,6 +38,8 @@ type CompleteMeta struct {
 type ChatEntry struct {
 	Role       string // RoleUser, RoleAssistant, RoleTool, RoleError, RoleSystem, RoleComplete
 	Content    string
+	Parts      []MessagePart // non-nil for assistant entries with mixed parts; nil for simple
+	CreatedAt  time.Time     // for timestamp display
 	ToolID     string        // tool call ID for matching updates
 	ToolName   string        // tool name (bash, read, write, etc.)
 	ToolStatus string        // StatusPending, StatusSuccess, StatusError
@@ -46,20 +48,27 @@ type ChatEntry struct {
 
 // Chat is a scrollable viewport displaying conversation messages.
 type Chat struct {
-	entries   []ChatEntry
-	scrollPos int
-	width     int
-	height    int
-	streaming string
-	mode      string
-	theme     *styles.Theme
+	entries        []ChatEntry
+	scrollPos      int
+	width          int
+	height         int
+	streaming      string        // legacy streaming content
+	streamingParts []MessagePart // part-based streaming accumulator
+	mode           string
+	theme          *styles.Theme
+
+	showThinking   bool // controls reasoning part visibility
+	showDetails    bool // controls tool output detail level
+	showTimestamps bool // controls timestamp prefix on entries
+	showCodeBlocks bool // true = show code, false = conceal
 }
 
 // NewChat creates a new chat component.
 func NewChat() Chat {
 	return Chat{
-		mode:  "build",
-		theme: styles.DefaultTheme,
+		mode:           "build",
+		theme:          styles.DefaultTheme,
+		showCodeBlocks: true,
 	}
 }
 
@@ -74,6 +83,30 @@ func (c *Chat) SetMode(mode string) { c.mode = mode }
 
 // SetTheme sets the theme.
 func (c *Chat) SetTheme(t *styles.Theme) { c.theme = t }
+
+// SetShowThinking controls whether reasoning parts are rendered.
+func (c *Chat) SetShowThinking(v bool) { c.showThinking = v }
+
+// ShowThinking reports whether reasoning parts are rendered.
+func (c Chat) ShowThinking() bool { return c.showThinking }
+
+// SetShowDetails controls whether tool output details are shown.
+func (c *Chat) SetShowDetails(v bool) { c.showDetails = v }
+
+// ShowDetails reports whether tool output details are shown.
+func (c Chat) ShowDetails() bool { return c.showDetails }
+
+// SetShowTimestamps controls whether timestamp prefixes are shown.
+func (c *Chat) SetShowTimestamps(v bool) { c.showTimestamps = v }
+
+// ShowTimestamps reports whether timestamp prefixes are shown.
+func (c Chat) ShowTimestamps() bool { return c.showTimestamps }
+
+// SetShowCodeBlocks controls whether fenced code blocks are visible.
+func (c *Chat) SetShowCodeBlocks(v bool) { c.showCodeBlocks = v }
+
+// ShowCodeBlocks reports whether fenced code blocks are visible.
+func (c Chat) ShowCodeBlocks() bool { return c.showCodeBlocks }
 
 // AddEntry adds a completed message to the chat.
 func (c *Chat) AddEntry(entry ChatEntry) {
@@ -92,14 +125,52 @@ func (c *Chat) UpdateLastTool(id string, entry ChatEntry) {
 	}
 }
 
-// StreamContent appends to the current streaming content.
+// StreamContent appends to the current streaming content (legacy path).
 func (c *Chat) StreamContent(delta string) {
 	c.streaming += delta
 	c.scrollToBottom()
 }
 
+// StreamPart appends a delta to the streaming parts accumulator.
+// If the last part matches the type, the delta is appended; otherwise a new part starts.
+func (c *Chat) StreamPart(typ PartType, delta string) {
+	if delta == "" {
+		return
+	}
+	if n := len(c.streamingParts); n > 0 && c.streamingParts[n-1].Type == typ {
+		c.streamingParts[n-1].Content += delta
+	} else {
+		c.streamingParts = append(c.streamingParts, MessagePart{Type: typ, Content: delta})
+	}
+	c.scrollToBottom()
+}
+
 // CommitStream finalizes streaming content as an assistant entry.
+// Handles both legacy streaming (single string) and part-based streaming.
 func (c *Chat) CommitStream() {
+	// Part-based streaming path
+	if len(c.streamingParts) > 0 {
+		// Single text part — fall back to Content field for backward compat
+		if len(c.streamingParts) == 1 && c.streamingParts[0].Type == PartText {
+			c.entries = append(c.entries, ChatEntry{
+				Role:    RoleAssistant,
+				Content: c.streamingParts[0].Content,
+			})
+		} else {
+			parts := make([]MessagePart, len(c.streamingParts))
+			copy(parts, c.streamingParts)
+			c.entries = append(c.entries, ChatEntry{
+				Role:    RoleAssistant,
+				Content: plainTextFromParts(parts),
+				Parts:   parts,
+			})
+		}
+		c.streamingParts = nil
+		c.streaming = ""
+		return
+	}
+
+	// Legacy streaming path
 	if c.streaming != "" {
 		c.entries = append(c.entries, ChatEntry{
 			Role:    RoleAssistant,
@@ -107,6 +178,17 @@ func (c *Chat) CommitStream() {
 		})
 		c.streaming = ""
 	}
+}
+
+// plainTextFromParts extracts and concatenates user-visible text segments.
+func plainTextFromParts(parts []MessagePart) string {
+	var b strings.Builder
+	for _, p := range parts {
+		if p.Type == PartText {
+			b.WriteString(p.Content)
+		}
+	}
+	return b.String()
 }
 
 // PageUp scrolls up by one page height.
@@ -209,6 +291,7 @@ func (c Chat) Entries() []ChatEntry {
 func (c *Chat) Clear() {
 	c.entries = nil
 	c.streaming = ""
+	c.streamingParts = nil
 	c.scrollPos = 0
 }
 
@@ -235,8 +318,10 @@ func (c Chat) View() string {
 		lines = append(lines, "") // blank line between entries
 	}
 
-	// Streaming content
-	if c.streaming != "" {
+	// Streaming content (part-based or legacy)
+	if len(c.streamingParts) > 0 {
+		lines = append(lines, c.renderAssistantParts(c.streamingParts, c.effectiveTheme())...)
+	} else if c.streaming != "" {
 		lines = append(lines, "   "+c.streaming)
 	}
 
@@ -266,11 +351,16 @@ func (c Chat) View() string {
 	return strings.Join(visible, "\n")
 }
 
-func (c Chat) renderEntry(entry ChatEntry) []string {
-	t := c.theme
-	if t == nil {
-		t = styles.DefaultTheme
+// effectiveTheme returns the chat's theme, falling back to the default.
+func (c Chat) effectiveTheme() *styles.Theme {
+	if c.theme != nil {
+		return c.theme
 	}
+	return styles.DefaultTheme
+}
+
+func (c Chat) renderEntry(entry ChatEntry) []string {
+	t := c.effectiveTheme()
 
 	switch entry.Role {
 	case RoleUser:
@@ -304,25 +394,81 @@ func (c Chat) renderUserEntry(entry ChatEntry, t *styles.Theme) []string {
 	contentLines := strings.Split(wrapped, "\n")
 
 	result := make([]string, 0, len(contentLines)+1)
-	for _, line := range contentLines {
-		result = append(result, accentStyle.Render("┃")+" "+line)
+	for i, line := range contentLines {
+		rendered := accentStyle.Render("┃") + " " + line
+		if i == 0 {
+			rendered = c.prependTimestamp(rendered, entry, t)
+		}
+		result = append(result, rendered)
 	}
 	result = append(result, accentStyle.Render("╹"))
 	return result
 }
 
 // renderAssistantEntry renders assistant messages with 3-space indent.
-func (c Chat) renderAssistantEntry(entry ChatEntry, _ *styles.Theme) []string {
+func (c Chat) renderAssistantEntry(entry ChatEntry, t *styles.Theme) []string {
+	if len(entry.Parts) > 0 {
+		result := c.renderAssistantParts(entry.Parts, t)
+		if len(result) > 0 {
+			result[0] = c.prependTimestamp(result[0], entry, t)
+		}
+		return result
+	}
+
 	maxWidth := c.width - 3
 	if maxWidth < 20 {
 		maxWidth = 20
 	}
 
-	wrapped := wrapText(entry.Content, maxWidth)
+	content := entry.Content
+	if !c.showCodeBlocks {
+		content = concealCodeBlocks(content)
+	}
+
+	wrapped := wrapText(content, maxWidth)
 	lines := strings.Split(wrapped, "\n")
 	result := make([]string, len(lines))
 	for i, line := range lines {
 		result[i] = "   " + line
+	}
+	if len(result) > 0 {
+		result[0] = c.prependTimestamp(result[0], entry, t)
+	}
+	return result
+}
+
+// renderAssistantParts renders a parts-based assistant message.
+func (c Chat) renderAssistantParts(parts []MessagePart, t *styles.Theme) []string {
+	maxWidth := c.width - 3
+	if maxWidth < 20 {
+		maxWidth = 20
+	}
+
+	var result []string
+	for _, p := range parts {
+		switch p.Type {
+		case PartReasoning:
+			if !c.showThinking {
+				continue
+			}
+			reasoningStyle := t.TextMutedStyle.Italic(true)
+			wrapped := wrapText(p.Content, maxWidth)
+			for _, line := range strings.Split(wrapped, "\n") {
+				result = append(result, "   "+reasoningStyle.Render(line))
+			}
+		default: // PartText and any future types
+			text := p.Content
+			if !c.showCodeBlocks {
+				text = concealCodeBlocks(text)
+			}
+			wrapped := wrapText(text, maxWidth)
+			for _, line := range strings.Split(wrapped, "\n") {
+				result = append(result, "   "+line)
+			}
+		}
+	}
+	if len(result) == 0 {
+		result = append(result, "   ")
 	}
 	return result
 }
@@ -377,7 +523,22 @@ func (c Chat) renderToolEntry(entry ChatEntry, t *styles.Theme) []string {
 		t.TextMutedStyle.Render(entry.ToolName) + " · " +
 		t.TextMutedStyle.Render(content)
 
-	return []string{line}
+	lines := []string{line}
+
+	if c.showDetails && entry.Content != "" && entry.ToolStatus != StatusPending {
+		maxW := c.width - 8
+		if maxW < 20 {
+			maxW = 20
+		}
+		for _, dl := range strings.Split(entry.Content, "\n") {
+			if lipgloss.Width(dl) > maxW {
+				dl = dl[:maxW]
+			}
+			lines = append(lines, "      "+t.TextMutedStyle.Render(dl))
+		}
+	}
+
+	return lines
 }
 
 // renderErrorEntry renders error messages.
@@ -425,6 +586,46 @@ func (c Chat) renderCompleteEntry(entry ChatEntry, t *styles.Theme) []string {
 	return []string{line}
 }
 
+// concealCodeBlocks replaces fenced code blocks (``` ... ```) with a placeholder.
+// Inline `code` is not affected. Unclosed blocks are concealed to end of string.
+func concealCodeBlocks(text string) string {
+	lines := strings.Split(text, "\n")
+	var result []string
+	inBlock := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !inBlock && strings.HasPrefix(trimmed, "```") {
+			inBlock = true
+			result = append(result, "[code block hidden]")
+			// Check if the same line closes it (e.g. ```code``` on one line)
+			// Only if there's a second ``` after the opening one
+			rest := trimmed[3:]
+			if idx := strings.Index(rest, "```"); idx >= 0 {
+				inBlock = false
+			}
+			continue
+		}
+		if inBlock {
+			if strings.HasPrefix(trimmed, "```") {
+				inBlock = false
+			}
+			continue
+		}
+		result = append(result, line)
+	}
+	return strings.Join(result, "\n")
+}
+
+// prependTimestamp prepends a 12-hour timestamp prefix to a line if timestamps are enabled
+// and the entry has a non-zero CreatedAt.
+func (c Chat) prependTimestamp(line string, entry ChatEntry, t *styles.Theme) string {
+	if !c.showTimestamps || entry.CreatedAt.IsZero() {
+		return line
+	}
+	ts := entry.CreatedAt.Format("3:04 PM")
+	return t.TextMutedStyle.Render(ts+"  ") + line
+}
+
 func (c *Chat) scrollToBottom() {
 	c.scrollPos = max(0, c.totalLines()-c.height)
 }
@@ -434,7 +635,9 @@ func (c Chat) totalLines() int {
 	for _, entry := range c.entries {
 		count += len(c.renderEntry(entry)) + 1
 	}
-	if c.streaming != "" {
+	if len(c.streamingParts) > 0 {
+		count += len(c.renderAssistantParts(c.streamingParts, c.effectiveTheme()))
+	} else if c.streaming != "" {
 		count++
 	}
 	return count

--- a/internal/tui/components/chat.go
+++ b/internal/tui/components/chat.go
@@ -154,7 +154,7 @@ func (c *Chat) StreamPart(typ PartType, delta string) {
 		return
 	}
 	if !typ.Valid() {
-		store.LogError(fmt.Sprintf("chat: StreamPart called with invalid type %q", typ), nil)
+		store.LogErrorf("chat: StreamPart called with invalid type %q", typ)
 	}
 	if n := len(c.streamingParts); n > 0 && c.streamingParts[n-1].Type == typ {
 		c.streamingParts[n-1].Content += delta
@@ -173,6 +173,9 @@ func (c *Chat) CommitStream() {
 
 	// Part-based streaming path — takes precedence over legacy
 	if len(c.streamingParts) > 0 {
+		if c.streaming != "" {
+			store.LogError("chat: CommitStream called with both streamingParts and legacy streaming populated; legacy content discarded", nil)
+		}
 		// Single text part — fall back to Content field for backward compat
 		if len(c.streamingParts) == 1 && c.streamingParts[0].Type == PartText {
 			c.entries = append(c.entries, ChatEntry{
@@ -403,6 +406,7 @@ func (c Chat) renderEntry(entry ChatEntry) []string {
 	case RoleComplete:
 		return c.renderCompleteEntry(entry, t)
 	default:
+		store.LogErrorf("chat: unknown entry role %q rendered as plain text", entry.Role)
 		return []string{entry.Content}
 	}
 }
@@ -473,31 +477,42 @@ func (c Chat) renderAssistantParts(parts []MessagePart, t *styles.Theme) []strin
 
 	var result []string
 	inConcealedBlock := false
+	var textBuf strings.Builder
+	flushText := func() {
+		if textBuf.Len() == 0 {
+			return
+		}
+		wrapped := wrapText(textBuf.String(), maxWidth)
+		for _, line := range strings.Split(wrapped, "\n") {
+			result = append(result, "   "+line)
+		}
+		textBuf.Reset()
+	}
+
 	for _, p := range parts {
 		switch p.Type {
 		case PartReasoning:
 			if !c.showThinking {
 				continue
 			}
+			flushText()
 			reasoningStyle := t.TextMutedStyle.Italic(true)
 			wrapped := wrapText(p.Content, maxWidth)
 			for _, line := range strings.Split(wrapped, "\n") {
 				result = append(result, "   "+reasoningStyle.Render(line))
 			}
-		default: // PartText and any future types — render as text
+		default: // PartText or unknown (unknown types are logged and rendered as text)
 			if p.Type != PartText {
-				store.LogError(fmt.Sprintf("chat: unknown part type %q rendered as text", p.Type), nil)
+				store.LogErrorf("chat: unknown part type %q rendered as text", p.Type)
 			}
 			text := p.Content
 			if !c.showCodeBlocks {
 				text, inConcealedBlock = concealCodeBlocksWithState(text, inConcealedBlock)
 			}
-			wrapped := wrapText(text, maxWidth)
-			for _, line := range strings.Split(wrapped, "\n") {
-				result = append(result, "   "+line)
-			}
+			textBuf.WriteString(text)
 		}
 	}
+	flushText()
 	if len(result) == 0 {
 		// All parts were hidden reasoning — show muted indicator
 		hasReasoning := slices.ContainsFunc(parts, func(p MessagePart) bool {

--- a/internal/tui/components/chat_test.go
+++ b/internal/tui/components/chat_test.go
@@ -4,7 +4,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
+	"charm.land/lipgloss/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,6 +17,19 @@ func TestChat_AddEntry(t *testing.T) {
 	c.AddEntry(ChatEntry{Role: RoleUser, Content: "hello"})
 	view := c.View()
 	assert.Contains(t, view, "hello")
+}
+
+func TestChat_AddEntry_SetsCreatedAtWhenUnset(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	before := time.Now()
+	c.AddEntry(ChatEntry{Role: RoleUser, Content: "hello"})
+
+	entries := c.Entries()
+	assert.Len(t, entries, 1)
+	assert.False(t, entries[0].CreatedAt.IsZero(), "add entry should default CreatedAt")
+	assert.False(t, entries[0].CreatedAt.Before(before), "CreatedAt should be set at add time")
 }
 
 func TestChat_UserMessage_HasAccentBorder(t *testing.T) {
@@ -412,4 +427,35 @@ func TestChat_HiddenReasoning_PreservesAssistantTextFlow(t *testing.T) {
 
 	view := c.View()
 	assert.Contains(t, view, "The sea is calm tonight.")
+}
+
+func TestChat_RenderUserEntry_TimestampedFirstLine_RespectsViewportWidth(t *testing.T) {
+	c := NewChat()
+	c.SetSize(40, 20)
+	c.SetShowTimestamps(true)
+
+	lines := c.renderUserEntry(ChatEntry{
+		Role:      RoleUser,
+		Content:   strings.TrimSpace(strings.Repeat("word ", 9)),
+		CreatedAt: time.Date(2026, time.January, 1, 15, 4, 0, 0, time.UTC),
+	}, c.effectiveTheme())
+
+	assert.NotEmpty(t, lines)
+	assert.LessOrEqual(t, lipgloss.Width(lines[0]), c.width, "timestamp prefix should be accounted for in wrapping")
+}
+
+func TestChat_RenderToolEntry_DetailsTruncation_PreservesUTF8(t *testing.T) {
+	c := NewChat()
+	c.SetSize(28, 20) // details width = 20
+	c.SetShowDetails(true)
+
+	lines := c.renderToolEntry(ChatEntry{
+		Role:       RoleTool,
+		Content:    strings.Repeat("a", 19) + "éz",
+		ToolName:   "read",
+		ToolStatus: StatusSuccess,
+	}, c.effectiveTheme())
+
+	assert.GreaterOrEqual(t, len(lines), 2, "details line should render")
+	assert.True(t, utf8.ValidString(lines[1]), "detail truncation should not cut through UTF-8 bytes")
 }

--- a/internal/tui/components/chat_test.go
+++ b/internal/tui/components/chat_test.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -335,4 +336,27 @@ func TestChat_PrevUserMessage_UsesRenderedHeights(t *testing.T) {
 	c.PrevUserMessage()
 
 	assert.Equal(t, firstOffset, c.scrollPos)
+}
+
+func TestChat_ConcealCodeAcrossInterleavedParts(t *testing.T) {
+	c := NewChat()
+	c.SetSize(100, 20)
+	c.SetShowCodeBlocks(false)
+	c.SetShowThinking(true)
+
+	c.AddEntry(ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartText, Content: "```go\nfmt"},
+			{Type: PartReasoning, Content: "thinking"},
+			{Type: PartText, Content: ".Println(1)\n```\nAfter"},
+		},
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "[code block hidden]")
+	assert.Equal(t, 1, strings.Count(view, "[code block hidden]"))
+	assert.NotContains(t, view, "Println(1)")
+	assert.Contains(t, view, "thinking")
+	assert.Contains(t, view, "After")
 }

--- a/internal/tui/components/chat_test.go
+++ b/internal/tui/components/chat_test.go
@@ -153,6 +153,41 @@ func TestChat_Clear(t *testing.T) {
 	assert.NotContains(t, view, "hello")
 }
 
+func TestChat_Clear_ResetsStreamingParts(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.StreamPart(PartText, "streaming content")
+	c.Clear()
+
+	assert.Empty(t, c.streamingParts, "Clear should reset streamingParts")
+	assert.Empty(t, c.streaming, "Clear should reset legacy streaming")
+	assert.Equal(t, 0, c.scrollPos, "Clear should reset scroll position")
+}
+
+func TestChat_RenderEntry_UnknownRole_RendersAsPlainText(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	c.AddEntry(ChatEntry{Role: "unknown", Content: "mystery content"})
+	view := c.View()
+	assert.Contains(t, view, "mystery content")
+}
+
+func TestChat_CommitStream_BothPaths_LogsWarning(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	// Populate both paths
+	c.StreamContent("legacy")
+	c.StreamPart(PartText, "parts")
+	c.CommitStream()
+
+	// Parts should win, legacy discarded
+	entries := c.Entries()
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "parts", entries[0].Content)
+}
+
 func TestChat_Entries_ReturnsAllEntries(t *testing.T) {
 	c := NewChat()
 	c.AddEntry(ChatEntry{Role: RoleUser, Content: "hello"})
@@ -359,4 +394,22 @@ func TestChat_ConcealCodeAcrossInterleavedParts(t *testing.T) {
 	assert.NotContains(t, view, "Println(1)")
 	assert.Contains(t, view, "thinking")
 	assert.Contains(t, view, "After")
+}
+
+func TestChat_HiddenReasoning_PreservesAssistantTextFlow(t *testing.T) {
+	c := NewChat()
+	c.SetSize(100, 20)
+	c.SetShowThinking(false)
+
+	c.AddEntry(ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartText, Content: "The sea is "},
+			{Type: PartReasoning, Content: "hidden reasoning"},
+			{Type: PartText, Content: "calm tonight."},
+		},
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "The sea is calm tonight.")
 }

--- a/internal/tui/components/conceal_test.go
+++ b/internal/tui/components/conceal_test.go
@@ -148,3 +148,10 @@ func TestChat_ConcealAcrossInterleavedParts(t *testing.T) {
 	assert.Contains(t, view, "thinking")
 	assert.Contains(t, view, "After")
 }
+
+func TestConcealCodeBlocks_FenceAtEndOfText(t *testing.T) {
+	input := "Before\n```"
+	result := concealCodeBlocks(input)
+	assert.Contains(t, result, "Before")
+	assert.Contains(t, result, "[code block hidden]")
+}

--- a/internal/tui/components/conceal_test.go
+++ b/internal/tui/components/conceal_test.go
@@ -1,0 +1,150 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConcealCodeBlocks_NoCodeBlocks(t *testing.T) {
+	input := "This is normal text without code."
+	assert.Equal(t, input, concealCodeBlocks(input))
+}
+
+func TestConcealCodeBlocks_SingleFencedBlock(t *testing.T) {
+	input := "Before\n```go\nfunc main() {}\n```\nAfter"
+	result := concealCodeBlocks(input)
+	assert.Contains(t, result, "Before")
+	assert.Contains(t, result, "After")
+	assert.Contains(t, result, "[code block hidden]")
+	assert.NotContains(t, result, "func main")
+}
+
+func TestConcealCodeBlocks_MultipleFencedBlocks(t *testing.T) {
+	input := "Start\n```\nblock1\n```\nMiddle\n```python\nblock2\n```\nEnd"
+	result := concealCodeBlocks(input)
+	assert.Contains(t, result, "Start")
+	assert.Contains(t, result, "Middle")
+	assert.Contains(t, result, "End")
+	assert.NotContains(t, result, "block1")
+	assert.NotContains(t, result, "block2")
+}
+
+func TestConcealCodeBlocks_UnclosedBlock(t *testing.T) {
+	input := "Before\n```\nunclosed code\nmore code"
+	result := concealCodeBlocks(input)
+	assert.Contains(t, result, "Before")
+	assert.Contains(t, result, "[code block hidden]")
+	assert.NotContains(t, result, "unclosed code")
+}
+
+func TestConcealCodeBlocks_InlineCode_NotConcealed(t *testing.T) {
+	input := "Use `inline code` here."
+	assert.Equal(t, input, concealCodeBlocks(input))
+}
+
+func TestConcealCodeBlocks_EmptyFencedBlock(t *testing.T) {
+	input := "Before\n```\n```\nAfter"
+	result := concealCodeBlocks(input)
+	assert.Contains(t, result, "Before")
+	assert.Contains(t, result, "After")
+	assert.Contains(t, result, "[code block hidden]")
+}
+
+func TestChat_RenderWithConcealedCode(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowCodeBlocks(false)
+
+	c.AddEntry(ChatEntry{
+		Role:    RoleAssistant,
+		Content: "Here is code:\n```go\nfunc main() {}\n```\nDone.",
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "Here is code:")
+	assert.Contains(t, view, "[code block hidden]")
+	assert.NotContains(t, view, "func main")
+	assert.Contains(t, view, "Done.")
+}
+
+func TestChat_RenderWithVisibleCode(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowCodeBlocks(true) // default
+
+	c.AddEntry(ChatEntry{
+		Role:    RoleAssistant,
+		Content: "Here is code:\n```go\nfunc main() {}\n```\nDone.",
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "func main")
+	assert.NotContains(t, view, "[code block hidden]")
+}
+
+func TestChat_ConcealAffectsPartsText(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowCodeBlocks(false)
+	c.SetShowThinking(true)
+
+	c.AddEntry(ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartText, Content: "Text\n```\ncode\n```\nMore"},
+		},
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "Text")
+	assert.Contains(t, view, "[code block hidden]")
+	assert.NotContains(t, view, "code\n")
+}
+
+func TestConcealCodeBlocks_NestedBackticks(t *testing.T) {
+	// Content with ``` inside code that's already inside a fenced block
+	input := "Before\n```\nsome `inline` code\n```\nAfter"
+	result := concealCodeBlocks(input)
+	assert.Contains(t, result, "Before")
+	assert.Contains(t, result, "After")
+	assert.Contains(t, result, "[code block hidden]")
+	assert.NotContains(t, result, "some `inline` code")
+}
+
+func TestConcealCodeBlocks_FourBackticksFence(t *testing.T) {
+	// ```` is treated the same as ``` — any ``` prefix starts/closes a fence.
+	// The inner ``` closes the ```` block, then func main is visible,
+	// then the second ``` starts a new block that ```` closes.
+	input := "Text\n````\ninner\n```\nfunc main() {}\n```\nouter\n````\nEnd"
+	result := concealCodeBlocks(input)
+	assert.Contains(t, result, "Text")
+	assert.Contains(t, result, "[code block hidden]")
+	// The ``` inside closes the first block, so "func main" becomes visible
+	assert.Contains(t, result, "func main")
+	assert.Contains(t, result, "End")
+}
+
+func TestChat_ConcealAcrossInterleavedParts(t *testing.T) {
+	c := NewChat()
+	c.SetSize(100, 20)
+	c.SetShowCodeBlocks(false)
+	c.SetShowThinking(true)
+
+	c.AddEntry(ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartText, Content: "```go\nfmt"},
+			{Type: PartReasoning, Content: "thinking"},
+			{Type: PartText, Content: ".Println(1)\n```\nAfter"},
+		},
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "[code block hidden]")
+	assert.Equal(t, 1, strings.Count(view, "[code block hidden]"))
+	assert.NotContains(t, view, "Println(1)")
+	assert.Contains(t, view, "thinking")
+	assert.Contains(t, view, "After")
+}

--- a/internal/tui/components/conceal_test.go
+++ b/internal/tui/components/conceal_test.go
@@ -149,6 +149,34 @@ func TestChat_ConcealAcrossInterleavedParts(t *testing.T) {
 	assert.Contains(t, view, "After")
 }
 
+func TestChat_StreamingParts_ConcealCodeBlock(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowCodeBlocks(false)
+
+	c.StreamPart(PartText, "Before\n```go\nfunc main() {}\n```\nAfter")
+
+	view := c.View()
+	assert.Contains(t, view, "Before")
+	assert.Contains(t, view, "[code block hidden]")
+	assert.NotContains(t, view, "func main")
+	assert.Contains(t, view, "After")
+}
+
+func TestChat_StreamingParts_ConcealUnclosedBlock(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowCodeBlocks(false)
+
+	// Code block opened but not closed during streaming
+	c.StreamPart(PartText, "Before\n```go\nfunc main")
+
+	view := c.View()
+	assert.Contains(t, view, "Before")
+	assert.Contains(t, view, "[code block hidden]")
+	assert.NotContains(t, view, "func main")
+}
+
 func TestConcealCodeBlocks_FenceAtEndOfText(t *testing.T) {
 	input := "Before\n```"
 	result := concealCodeBlocks(input)

--- a/internal/tui/components/helpers.go
+++ b/internal/tui/components/helpers.go
@@ -1,0 +1,22 @@
+package components
+
+import "strings"
+
+// truncateStr shortens s to at most n characters, adding "..." if truncated.
+func truncateStr(s string, n int) string {
+	if n < 4 {
+		return s
+	}
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-3] + "..."
+}
+
+// firstLine returns the content up to the first newline, or the full string.
+func firstLine(s string) string {
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		return s[:idx]
+	}
+	return s
+}

--- a/internal/tui/components/parts.go
+++ b/internal/tui/components/parts.go
@@ -23,15 +23,29 @@ func (p MessagePart) Valid() error {
 	return nil
 }
 
+// allPartsContent concatenates content from all parts.
+func (e ChatEntry) allPartsContent() string {
+	var b strings.Builder
+	for _, p := range e.Parts {
+		b.WriteString(p.Content)
+	}
+	return b.String()
+}
+
+// FullContent returns all parts content including reasoning.
+// Falls back to Content when no parts exist.
+func (e ChatEntry) FullContent() string {
+	if len(e.Parts) == 0 {
+		return e.Content
+	}
+	return e.allPartsContent()
+}
+
 // CopyableContent returns the best content for clipboard copy.
 // Uses Content if non-empty; otherwise concatenates all parts content.
 func (e ChatEntry) CopyableContent() string {
 	if e.Content != "" {
 		return e.Content
 	}
-	var b strings.Builder
-	for _, p := range e.Parts {
-		b.WriteString(p.Content)
-	}
-	return b.String()
+	return e.allPartsContent()
 }

--- a/internal/tui/components/parts.go
+++ b/internal/tui/components/parts.go
@@ -23,6 +23,42 @@ func (p MessagePart) Valid() error {
 	return nil
 }
 
+// validRole reports whether r is a known ChatEntry role.
+func validRole(r string) bool {
+	switch r {
+	case RoleUser, RoleAssistant, RoleTool, RoleError, RoleSystem, RoleComplete:
+		return true
+	default:
+		return false
+	}
+}
+
+// Valid checks that the ChatEntry has a recognized role, valid parts, and
+// consistent Content/Parts fields.
+func (e ChatEntry) Valid() error {
+	if !validRole(e.Role) {
+		return fmt.Errorf("invalid role: %q", e.Role)
+	}
+	if e.Role == RoleTool && e.ToolID == "" {
+		return fmt.Errorf("tool entry requires ToolID")
+	}
+	if e.Role == RoleComplete && e.Meta == nil {
+		return fmt.Errorf("complete entry requires Meta")
+	}
+	for i, p := range e.Parts {
+		if err := p.Valid(); err != nil {
+			return fmt.Errorf("part[%d]: %w", i, err)
+		}
+	}
+	if len(e.Parts) > 0 && e.Content != "" {
+		expected := plainTextFromParts(e.Parts)
+		if e.Content != expected {
+			return fmt.Errorf("Content mismatch: got %q, want %q (from text parts)", e.Content, expected)
+		}
+	}
+	return nil
+}
+
 // allPartsContent concatenates content from all parts.
 func (e ChatEntry) allPartsContent() string {
 	var b strings.Builder
@@ -42,7 +78,7 @@ func (e ChatEntry) FullContent() string {
 }
 
 // CopyableContent returns the best content for clipboard copy.
-// Uses Content if non-empty; otherwise concatenates all parts content.
+// Uses Content if non-empty; otherwise concatenates all parts (including reasoning).
 func (e ChatEntry) CopyableContent() string {
 	if e.Content != "" {
 		return e.Content

--- a/internal/tui/components/parts.go
+++ b/internal/tui/components/parts.go
@@ -34,7 +34,9 @@ func validRole(r string) bool {
 }
 
 // Valid checks that the ChatEntry has a recognized role, valid parts, and
-// consistent Content/Parts fields.
+// consistent Content/Parts fields. When both Parts and Content are populated,
+// Content must equal the concatenation of text-only parts — this catches
+// bugs where Content is set independently rather than derived from Parts.
 func (e ChatEntry) Valid() error {
 	if !validRole(e.Role) {
 		return fmt.Errorf("invalid role: %q", e.Role)
@@ -78,7 +80,9 @@ func (e ChatEntry) FullContent() string {
 }
 
 // CopyableContent returns the best content for clipboard copy.
-// Uses Content if non-empty; otherwise concatenates all parts (including reasoning).
+// Uses Content if non-empty (text-only responses); otherwise concatenates
+// all parts including reasoning. This ensures reasoning-only entries
+// (where Content is empty) are still copyable.
 func (e ChatEntry) CopyableContent() string {
 	if e.Content != "" {
 		return e.Content

--- a/internal/tui/components/parts.go
+++ b/internal/tui/components/parts.go
@@ -1,0 +1,37 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Valid reports whether the PartType is a recognized variant.
+func (pt PartType) Valid() bool {
+	switch pt {
+	case PartText, PartReasoning:
+		return true
+	default:
+		return false
+	}
+}
+
+// Valid checks that the MessagePart has a recognized type.
+func (p MessagePart) Valid() error {
+	if !p.Type.Valid() {
+		return fmt.Errorf("invalid part type: %q", p.Type)
+	}
+	return nil
+}
+
+// CopyableContent returns the best content for clipboard copy.
+// Uses Content if non-empty; otherwise concatenates all parts content.
+func (e ChatEntry) CopyableContent() string {
+	if e.Content != "" {
+		return e.Content
+	}
+	var b strings.Builder
+	for _, p := range e.Parts {
+		b.WriteString(p.Content)
+	}
+	return b.String()
+}

--- a/internal/tui/components/parts_test.go
+++ b/internal/tui/components/parts_test.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -63,6 +64,39 @@ func TestMessagePart_Valid_InvalidType(t *testing.T) {
 func TestMessagePart_Valid_EmptyType(t *testing.T) {
 	p := MessagePart{Type: "", Content: "x"}
 	assert.Error(t, p.Valid())
+}
+
+// --- StreamPart validation tests ---
+
+func TestChat_StreamPart_InvalidType_StillAccumulates(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	c.StreamPart(PartType("bogus"), "content")
+
+	// Should still accumulate — logging is best-effort, not blocking
+	assert.Len(t, c.streamingParts, 1)
+	assert.Equal(t, PartType("bogus"), c.streamingParts[0].Type)
+	assert.Equal(t, "content", c.streamingParts[0].Content)
+}
+
+// --- Unknown PartType rendering ---
+
+func TestChat_RenderAssistantParts_UnknownType_RenderedAsText(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	c.AddEntry(ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartType("future_type"), Content: "future content"},
+		},
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "future content", "unknown type should render as text")
 }
 
 // --- StreamPart tests ---
@@ -198,6 +232,20 @@ func TestChat_CommitStream_ClearsStreamingParts(t *testing.T) {
 	assert.Empty(t, c.streamingParts)
 }
 
+func TestChat_CommitStream_SetsCreatedAt(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	before := time.Now()
+	c.StreamPart(PartText, "hello")
+	c.CommitStream()
+
+	entries := c.Entries()
+	assert.Len(t, entries, 1)
+	assert.False(t, entries[0].CreatedAt.IsZero(), "committed stream entries should have CreatedAt")
+	assert.False(t, entries[0].CreatedAt.Before(before), "CreatedAt should be set at commit time")
+}
+
 func TestChat_CommitStream_LegacyStreamContent_StillWorks(t *testing.T) {
 	c := NewChat()
 	c.SetSize(80, 20)
@@ -209,6 +257,32 @@ func TestChat_CommitStream_LegacyStreamContent_StillWorks(t *testing.T) {
 	entries := c.Entries()
 	assert.Len(t, entries, 1)
 	assert.Equal(t, "legacy content", entries[0].Content)
+}
+
+// --- CopyableContent tests ---
+
+// --- FullContent tests ---
+
+func TestChatEntry_FullContent_NoParts_ReturnsContent(t *testing.T) {
+	e := ChatEntry{Role: RoleAssistant, Content: "plain text"}
+	assert.Equal(t, "plain text", e.FullContent())
+}
+
+func TestChatEntry_FullContent_WithParts_IncludesReasoning(t *testing.T) {
+	e := ChatEntry{
+		Role:    RoleAssistant,
+		Content: "visible only",
+		Parts: []MessagePart{
+			{Type: PartReasoning, Content: "thinking deeply"},
+			{Type: PartText, Content: "visible only"},
+		},
+	}
+	assert.Equal(t, "thinking deeplyvisible only", e.FullContent())
+}
+
+func TestChatEntry_FullContent_Empty(t *testing.T) {
+	e := ChatEntry{Role: RoleAssistant}
+	assert.Equal(t, "", e.FullContent())
 }
 
 // --- CopyableContent tests ---

--- a/internal/tui/components/parts_test.go
+++ b/internal/tui/components/parts_test.go
@@ -319,6 +319,91 @@ func TestChatEntry_CopyableContent_Empty(t *testing.T) {
 	assert.Equal(t, "", e.CopyableContent())
 }
 
+// --- ChatEntry.Valid tests ---
+
+func TestChatEntry_Valid_SimpleUser(t *testing.T) {
+	e := ChatEntry{Role: RoleUser, Content: "hello"}
+	assert.NoError(t, e.Valid())
+}
+
+func TestChatEntry_Valid_SimpleAssistant(t *testing.T) {
+	e := ChatEntry{Role: RoleAssistant, Content: "reply"}
+	assert.NoError(t, e.Valid())
+}
+
+func TestChatEntry_Valid_AssistantWithParts(t *testing.T) {
+	e := ChatEntry{
+		Role:    RoleAssistant,
+		Content: "visible",
+		Parts: []MessagePart{
+			{Type: PartReasoning, Content: "thinking"},
+			{Type: PartText, Content: "visible"},
+		},
+	}
+	assert.NoError(t, e.Valid())
+}
+
+func TestChatEntry_Valid_UnknownRole(t *testing.T) {
+	e := ChatEntry{Role: "bogus"}
+	err := e.Valid()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid role")
+}
+
+func TestChatEntry_Valid_EmptyRole(t *testing.T) {
+	e := ChatEntry{Role: ""}
+	assert.Error(t, e.Valid())
+}
+
+func TestChatEntry_Valid_ToolRequiresToolID(t *testing.T) {
+	e := ChatEntry{Role: RoleTool, ToolName: "bash", ToolID: ""}
+	err := e.Valid()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ToolID")
+}
+
+func TestChatEntry_Valid_ToolWithID(t *testing.T) {
+	e := ChatEntry{Role: RoleTool, ToolName: "bash", ToolID: "t1", ToolStatus: StatusPending}
+	assert.NoError(t, e.Valid())
+}
+
+func TestChatEntry_Valid_CompleteRequiresMeta(t *testing.T) {
+	e := ChatEntry{Role: RoleComplete}
+	err := e.Valid()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Meta")
+}
+
+func TestChatEntry_Valid_CompleteWithMeta(t *testing.T) {
+	e := ChatEntry{Role: RoleComplete, Meta: &CompleteMeta{Mode: "build", Model: "gpt-4"}}
+	assert.NoError(t, e.Valid())
+}
+
+func TestChatEntry_Valid_PartsContentMismatch(t *testing.T) {
+	e := ChatEntry{
+		Role:    RoleAssistant,
+		Content: "wrong content",
+		Parts: []MessagePart{
+			{Type: PartText, Content: "correct content"},
+		},
+	}
+	err := e.Valid()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Content mismatch")
+}
+
+func TestChatEntry_Valid_InvalidPart(t *testing.T) {
+	e := ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartType("bogus"), Content: "x"},
+		},
+	}
+	err := e.Valid()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "part[0]")
+}
+
 // --- CommitStream dual-path test ---
 
 func TestChat_CommitStream_BothPathsPopulated_PartsWin(t *testing.T) {

--- a/internal/tui/components/parts_test.go
+++ b/internal/tui/components/parts_test.go
@@ -595,6 +595,41 @@ func TestChat_StreamingParts_ReasoningHiddenWhenThinkingOff(t *testing.T) {
 	assert.Contains(t, view, "visible text")
 }
 
+// --- Narrow width rendering ---
+
+func TestChat_RenderAssistantParts_NarrowWidth(t *testing.T) {
+	c := NewChat()
+	c.SetSize(20, 10) // at minContentWidth boundary
+	c.SetShowThinking(true)
+
+	c.AddEntry(ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartReasoning, Content: "very long thinking text that wraps"},
+			{Type: PartText, Content: "answer"},
+		},
+	})
+
+	view := c.View()
+	assert.NotEmpty(t, view, "should render without panic at narrow width")
+	assert.Contains(t, view, "answer")
+}
+
+func TestChat_RenderAssistantParts_ZeroWidth_NoOutput(t *testing.T) {
+	c := NewChat()
+	c.SetSize(0, 10) // degenerate case
+
+	c.AddEntry(ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartText, Content: "hello"},
+		},
+	})
+
+	view := c.View()
+	assert.Empty(t, view, "zero width should produce empty view")
+}
+
 // --- Toggle setters ---
 
 func TestChat_SetShowThinking(t *testing.T) {

--- a/internal/tui/components/parts_test.go
+++ b/internal/tui/components/parts_test.go
@@ -1,0 +1,474 @@
+package components
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPartType_Constants(t *testing.T) {
+	assert.Equal(t, PartType("text"), PartText)
+	assert.Equal(t, PartType("reasoning"), PartReasoning)
+}
+
+func TestMessagePart_Creation(t *testing.T) {
+	p := MessagePart{Type: PartText, Content: "hello"}
+	assert.Equal(t, PartText, p.Type)
+	assert.Equal(t, "hello", p.Content)
+}
+
+func TestMessagePart_ReasoningCreation(t *testing.T) {
+	p := MessagePart{Type: PartReasoning, Content: "thinking..."}
+	assert.Equal(t, PartReasoning, p.Type)
+	assert.Equal(t, "thinking...", p.Content)
+}
+
+// --- PartType.Valid tests ---
+
+func TestPartType_Valid_Text(t *testing.T) {
+	assert.True(t, PartText.Valid())
+}
+
+func TestPartType_Valid_Reasoning(t *testing.T) {
+	assert.True(t, PartReasoning.Valid())
+}
+
+func TestPartType_Valid_Unknown(t *testing.T) {
+	assert.False(t, PartType("unknown").Valid())
+}
+
+func TestPartType_Valid_Empty(t *testing.T) {
+	assert.False(t, PartType("").Valid())
+}
+
+// --- MessagePart.Valid tests ---
+
+func TestMessagePart_Valid_TextOK(t *testing.T) {
+	p := MessagePart{Type: PartText, Content: "hello"}
+	assert.NoError(t, p.Valid())
+}
+
+func TestMessagePart_Valid_ReasoningOK(t *testing.T) {
+	p := MessagePart{Type: PartReasoning, Content: "think"}
+	assert.NoError(t, p.Valid())
+}
+
+func TestMessagePart_Valid_InvalidType(t *testing.T) {
+	p := MessagePart{Type: "bogus", Content: "x"}
+	err := p.Valid()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid part type")
+}
+
+func TestMessagePart_Valid_EmptyType(t *testing.T) {
+	p := MessagePart{Type: "", Content: "x"}
+	assert.Error(t, p.Valid())
+}
+
+// --- StreamPart tests ---
+
+func TestChat_StreamPart_TextAccumulates(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	c.StreamPart(PartText, "Hello ")
+	c.StreamPart(PartText, "world")
+
+	assert.Len(t, c.streamingParts, 1)
+	assert.Equal(t, PartText, c.streamingParts[0].Type)
+	assert.Equal(t, "Hello world", c.streamingParts[0].Content)
+}
+
+func TestChat_StreamPart_DifferentTypeStartsNew(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	c.StreamPart(PartText, "hello")
+	c.StreamPart(PartReasoning, "thinking")
+
+	assert.Len(t, c.streamingParts, 2)
+	assert.Equal(t, PartText, c.streamingParts[0].Type)
+	assert.Equal(t, "hello", c.streamingParts[0].Content)
+	assert.Equal(t, PartReasoning, c.streamingParts[1].Type)
+	assert.Equal(t, "thinking", c.streamingParts[1].Content)
+}
+
+func TestChat_StreamPart_InterleavedProducesThreeParts(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	c.StreamPart(PartText, "before ")
+	c.StreamPart(PartReasoning, "think ")
+	c.StreamPart(PartText, "after")
+
+	assert.Len(t, c.streamingParts, 3)
+	assert.Equal(t, PartText, c.streamingParts[0].Type)
+	assert.Equal(t, "before ", c.streamingParts[0].Content)
+	assert.Equal(t, PartReasoning, c.streamingParts[1].Type)
+	assert.Equal(t, "think ", c.streamingParts[1].Content)
+	assert.Equal(t, PartText, c.streamingParts[2].Type)
+	assert.Equal(t, "after", c.streamingParts[2].Content)
+}
+
+func TestChat_StreamPart_EmptyDeltaNoOp(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	c.StreamPart(PartText, "")
+	assert.Empty(t, c.streamingParts, "empty delta should not add parts")
+}
+
+func TestChat_StreamPart_EmptyDeltaAfterExistingNoOp(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	c.StreamPart(PartText, "hello")
+	c.StreamPart(PartText, "")
+
+	assert.Len(t, c.streamingParts, 1)
+	assert.Equal(t, "hello", c.streamingParts[0].Content)
+}
+
+// --- CommitStream with parts ---
+
+func TestChat_CommitStream_WithParts_CreatesPartsEntry(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	c.StreamPart(PartText, "hello ")
+	c.StreamPart(PartReasoning, "thinking")
+	c.CommitStream()
+
+	entries := c.Entries()
+	assert.Len(t, entries, 1)
+	assert.Equal(t, RoleAssistant, entries[0].Role)
+	assert.Len(t, entries[0].Parts, 2)
+	assert.Equal(t, PartText, entries[0].Parts[0].Type)
+	assert.Equal(t, "hello ", entries[0].Parts[0].Content)
+	assert.Equal(t, PartReasoning, entries[0].Parts[1].Type)
+	assert.Equal(t, "thinking", entries[0].Parts[1].Content)
+	assert.Equal(t, "hello ", entries[0].Content, "content should preserve text parts for copy/export compatibility")
+}
+
+func TestChat_CommitStream_WithInterleavedParts_PopulatesContentFromTextParts(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	c.StreamPart(PartText, "alpha ")
+	c.StreamPart(PartReasoning, "internal")
+	c.StreamPart(PartText, "omega")
+	c.CommitStream()
+
+	entries := c.Entries()
+	assert.Len(t, entries, 1)
+	assert.Equal(t, RoleAssistant, entries[0].Role)
+	assert.Equal(t, "alpha omega", entries[0].Content)
+	assert.Len(t, entries[0].Parts, 3)
+}
+
+func TestChat_CommitStream_SingleTextPart_FallsBackToContent(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	c.StreamPart(PartText, "simple response")
+	c.CommitStream()
+
+	entries := c.Entries()
+	assert.Len(t, entries, 1)
+	assert.Equal(t, RoleAssistant, entries[0].Role)
+	assert.Equal(t, "simple response", entries[0].Content)
+	assert.Nil(t, entries[0].Parts, "single text part should use Content field")
+}
+
+func TestChat_CommitStream_Empty_NoEntry(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	c.CommitStream()
+	assert.Empty(t, c.Entries(), "empty commit should not add entries")
+}
+
+func TestChat_CommitStream_ClearsStreamingParts(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	c.StreamPart(PartText, "hello")
+	c.CommitStream()
+
+	assert.Empty(t, c.streamingParts)
+}
+
+func TestChat_CommitStream_LegacyStreamContent_StillWorks(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	// Use legacy StreamContent path
+	c.StreamContent("legacy content")
+	c.CommitStream()
+
+	entries := c.Entries()
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "legacy content", entries[0].Content)
+}
+
+// --- CopyableContent tests ---
+
+func TestChatEntry_CopyableContent_UsesContent(t *testing.T) {
+	e := ChatEntry{Role: RoleAssistant, Content: "hello world"}
+	assert.Equal(t, "hello world", e.CopyableContent())
+}
+
+func TestChatEntry_CopyableContent_FallsBackToParts(t *testing.T) {
+	e := ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartReasoning, Content: "thinking deeply"},
+		},
+	}
+	assert.Equal(t, "thinking deeply", e.CopyableContent())
+}
+
+func TestChatEntry_CopyableContent_MixedParts(t *testing.T) {
+	e := ChatEntry{
+		Role:    RoleAssistant,
+		Content: "visible text",
+		Parts: []MessagePart{
+			{Type: PartReasoning, Content: "thinking"},
+			{Type: PartText, Content: "visible text"},
+		},
+	}
+	assert.Equal(t, "visible text", e.CopyableContent())
+}
+
+func TestChatEntry_CopyableContent_Empty(t *testing.T) {
+	e := ChatEntry{Role: RoleAssistant}
+	assert.Equal(t, "", e.CopyableContent())
+}
+
+// --- CommitStream dual-path test ---
+
+func TestChat_CommitStream_BothPathsPopulated_PartsWin(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	// Populate both paths — parts should take precedence
+	c.StreamPart(PartText, "part-based content")
+	c.streaming = "legacy content" // force legacy path too
+
+	c.CommitStream()
+
+	entries := c.Entries()
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "part-based content", entries[0].Content)
+	assert.Empty(t, c.streaming, "legacy streaming should be cleared")
+}
+
+// --- View with empty entries + streaming parts ---
+
+func TestChat_View_EmptyEntriesWithStreamingParts(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	// No committed entries, only streaming parts
+	c.StreamPart(PartText, "streaming text")
+
+	view := c.View()
+	assert.Contains(t, view, "streaming text")
+}
+
+// --- Rendering with parts ---
+
+func TestChat_RenderAssistantParts_TextOnly(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowThinking(true)
+
+	c.AddEntry(ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartText, Content: "hello world"},
+		},
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "hello world")
+}
+
+func TestChat_RenderAssistantParts_ReasoningVisible(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowThinking(true)
+
+	c.AddEntry(ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartReasoning, Content: "let me think"},
+			{Type: PartText, Content: "answer"},
+		},
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "let me think")
+	assert.Contains(t, view, "answer")
+}
+
+func TestChat_RenderAssistantParts_ReasoningHidden(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowThinking(false)
+
+	c.AddEntry(ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartReasoning, Content: "secret thinking"},
+			{Type: PartText, Content: "visible answer"},
+		},
+	})
+
+	view := c.View()
+	assert.NotContains(t, view, "secret thinking")
+	assert.Contains(t, view, "visible answer")
+}
+
+func TestChat_RenderAssistantParts_Interleaved(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowThinking(true)
+
+	c.AddEntry(ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartText, Content: "part one"},
+			{Type: PartReasoning, Content: "hmm"},
+			{Type: PartText, Content: "part two"},
+		},
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "part one")
+	assert.Contains(t, view, "hmm")
+	assert.Contains(t, view, "part two")
+}
+
+func TestChat_RenderAssistantParts_BackwardCompat_ContentField(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+
+	// Legacy entry with no Parts — should still render via Content
+	c.AddEntry(ChatEntry{Role: RoleAssistant, Content: "legacy text"})
+
+	view := c.View()
+	assert.Contains(t, view, "legacy text")
+}
+
+// --- Hidden reasoning indicator ---
+
+func TestChat_RenderAssistantParts_AllReasoningHidden_ShowsIndicator(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowThinking(false)
+
+	c.AddEntry(ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartReasoning, Content: "all reasoning, no text"},
+		},
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "thinking", "should show a [thinking] indicator when all parts are hidden reasoning")
+	assert.NotContains(t, view, "all reasoning, no text")
+}
+
+func TestChat_RenderAssistantParts_AllReasoningVisible_NoIndicator(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowThinking(true)
+
+	c.AddEntry(ChatEntry{
+		Role: RoleAssistant,
+		Parts: []MessagePart{
+			{Type: PartReasoning, Content: "reasoning content"},
+		},
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "reasoning content")
+	// Should NOT show the [thinking] indicator when thinking is visible
+	assert.NotContains(t, view, "[thinking]")
+}
+
+// --- Streaming parts in View ---
+
+func TestChat_StreamingParts_VisibleInView(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowThinking(true)
+
+	c.StreamPart(PartText, "streaming ")
+	c.StreamPart(PartText, "content")
+
+	view := c.View()
+	assert.Contains(t, view, "streaming content")
+}
+
+func TestChat_StreamingParts_ReasoningVisibleWhenThinkingOn(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowThinking(true)
+
+	c.StreamPart(PartReasoning, "thinking stream")
+
+	view := c.View()
+	assert.Contains(t, view, "thinking stream")
+}
+
+func TestChat_StreamingParts_ReasoningHiddenWhenThinkingOff(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowThinking(false)
+
+	c.StreamPart(PartReasoning, "hidden thinking")
+	c.StreamPart(PartText, "visible text")
+
+	view := c.View()
+	assert.NotContains(t, view, "hidden thinking")
+	assert.Contains(t, view, "visible text")
+}
+
+// --- Toggle setters ---
+
+func TestChat_SetShowThinking(t *testing.T) {
+	c := NewChat()
+	assert.False(t, c.showThinking)
+
+	c.SetShowThinking(true)
+	assert.True(t, c.showThinking)
+
+	c.SetShowThinking(false)
+	assert.False(t, c.showThinking)
+}
+
+func TestChat_SetShowDetails(t *testing.T) {
+	c := NewChat()
+	assert.False(t, c.showDetails)
+
+	c.SetShowDetails(true)
+	assert.True(t, c.showDetails)
+}
+
+func TestChat_SetShowTimestamps(t *testing.T) {
+	c := NewChat()
+	assert.False(t, c.showTimestamps)
+
+	c.SetShowTimestamps(true)
+	assert.True(t, c.showTimestamps)
+}
+
+func TestChat_SetShowCodeBlocks(t *testing.T) {
+	c := NewChat()
+	assert.True(t, c.showCodeBlocks, "default should be true (show code)")
+
+	c.SetShowCodeBlocks(false)
+	assert.False(t, c.showCodeBlocks)
+}

--- a/internal/tui/components/toolpanel.go
+++ b/internal/tui/components/toolpanel.go
@@ -69,17 +69,3 @@ func (tp ToolPanel) View() string {
 
 	return sb.String()
 }
-
-func truncateStr(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n-3] + "..."
-}
-
-func firstLine(s string) string {
-	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
-		return s[:idx]
-	}
-	return s
-}

--- a/internal/tui/dialog_export.go
+++ b/internal/tui/dialog_export.go
@@ -111,6 +111,8 @@ func (a *App) executeExport() tea.Cmd {
 			sb.WriteString("**Error:** " + e.Content + "\n\n")
 		case components.RoleSystem:
 			sb.WriteString("*" + e.Content + "*\n\n")
+		default:
+			store.LogErrorf("export: unknown entry role %q skipped", e.Role)
 		}
 	}
 

--- a/internal/tui/dialog_export.go
+++ b/internal/tui/dialog_export.go
@@ -92,7 +92,11 @@ func (a *App) executeExport() tea.Cmd {
 			sb.WriteString(e.Content + "\n\n")
 		case components.RoleAssistant:
 			sb.WriteString("## Assistant\n\n")
-			sb.WriteString(e.Content + "\n\n")
+			if a.exportDialog.includeThinking {
+				sb.WriteString(e.FullContent() + "\n\n")
+			} else {
+				sb.WriteString(e.Content + "\n\n")
+			}
 		case components.RoleTool:
 			if a.exportDialog.includeTools {
 				sb.WriteString(fmt.Sprintf("**Tool: %s** (%s)\n", e.ToolName, e.ToolStatus))

--- a/internal/tui/dialog_export.go
+++ b/internal/tui/dialog_export.go
@@ -83,6 +83,7 @@ func (a App) handleExportDialogKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 func (a *App) executeExport() tea.Cmd {
 	entries := a.chat.Entries()
 	var sb strings.Builder
+	var skipped int
 
 	sb.WriteString("# Session Export\n\n")
 	for _, e := range entries {
@@ -113,6 +114,7 @@ func (a *App) executeExport() tea.Cmd {
 			sb.WriteString("*" + e.Content + "*\n\n")
 		default:
 			store.LogErrorf("export: unknown entry role %q skipped", e.Role)
+			skipped++
 		}
 	}
 
@@ -126,6 +128,9 @@ func (a *App) executeExport() tea.Cmd {
 	}
 	if err := writeExportFile(exportPath, []byte(sb.String())); err != nil {
 		return a.ShowToast("Export failed: "+err.Error(), components.ToastError)
+	}
+	if skipped > 0 {
+		return a.ShowToast(fmt.Sprintf("Exported to %s (%d entries skipped)", exportPath, skipped), components.ToastWarning)
 	}
 	return a.ShowToast("Exported to "+exportPath, components.ToastSuccess)
 }

--- a/internal/tui/dialog_export_test.go
+++ b/internal/tui/dialog_export_test.go
@@ -318,5 +318,77 @@ func TestWriteExportFile_RenameFailure_PreservesExistingTarget(t *testing.T) {
 	assert.Equal(t, "original", string(data))
 }
 
+func TestApp_ExportDialog_IncludeThinking_WritesReasoningParts(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	sess := session.New(t.TempDir())
+	app.SetSession(sess)
+	app.SetAgent(agent.BuildAgent())
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+
+	// Add a part-based assistant entry with reasoning
+	a.chat.Clear()
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "question"})
+	a.chat.StreamPart(components.PartReasoning, "deep thinking")
+	a.chat.StreamPart(components.PartText, "visible answer")
+	a.chat.CommitStream()
+
+	// Open export dialog with includeThinking enabled
+	model, _ = a.Update(components.InputSubmitMsg{Value: "/export"})
+	a = model.(App)
+	a.exportDialog.includeThinking = true
+	a.exportDialog.filename = "thinking-export.md"
+	a.exportDialog.focusedField = 3
+
+	model, _ = a.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	a = model.(App)
+
+	data, err := os.ReadFile(filepath.Join(sess.WorkDir, "thinking-export.md"))
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, "deep thinking", "reasoning should be included when includeThinking is true")
+	assert.Contains(t, content, "visible answer")
+}
+
+func TestApp_ExportDialog_ExcludeThinking_OmitsReasoningParts(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	sess := session.New(t.TempDir())
+	app.SetSession(sess)
+	app.SetAgent(agent.BuildAgent())
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+
+	// Add a part-based assistant entry with reasoning
+	a.chat.Clear()
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "question"})
+	a.chat.StreamPart(components.PartReasoning, "secret thinking")
+	a.chat.StreamPart(components.PartText, "visible answer")
+	a.chat.CommitStream()
+
+	// Open export dialog with includeThinking disabled
+	model, _ = a.Update(components.InputSubmitMsg{Value: "/export"})
+	a = model.(App)
+	a.exportDialog.includeThinking = false
+	a.exportDialog.filename = "no-thinking-export.md"
+	a.exportDialog.focusedField = 3
+
+	model, _ = a.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	a = model.(App)
+
+	data, err := os.ReadFile(filepath.Join(sess.WorkDir, "no-thinking-export.md"))
+	require.NoError(t, err)
+	content := string(data)
+	assert.NotContains(t, content, "secret thinking", "reasoning should be excluded when includeThinking is false")
+	assert.Contains(t, content, "visible answer")
+}
+
 // Ensure unused imports don't cause issues
 var _ = provider.ModelInfo{}

--- a/internal/tui/dialog_export_test.go
+++ b/internal/tui/dialog_export_test.go
@@ -96,6 +96,25 @@ func TestApp_ExportDialog_WritesFile(t *testing.T) {
 	}
 }
 
+func TestApp_ExportDialog_WritesMixedPartsAssistantContent(t *testing.T) {
+	a := makeSessionApp(t)
+	a.chat.Clear()
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "question"})
+	a.chat.StreamPart(components.PartReasoning, "internal")
+	a.chat.StreamPart(components.PartText, "final answer")
+	a.chat.CommitStream()
+
+	model, _ := a.Update(components.InputSubmitMsg{Value: "/export"})
+	a = model.(App)
+	model, _ = a.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	a = model.(App)
+
+	exportPath := filepath.Join(a.session.WorkDir, a.exportDialog.filename)
+	data, err := os.ReadFile(exportPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "final answer")
+}
+
 func TestApp_ExportDialog_EmptyChat_ShowsWarning(t *testing.T) {
 	// Create an app without the 30 pre-loaded entries from makeSessionApp
 	app := NewApp()

--- a/internal/tui/dialog_export_test.go
+++ b/internal/tui/dialog_export_test.go
@@ -390,5 +390,44 @@ func TestApp_ExportDialog_ExcludeThinking_OmitsReasoningParts(t *testing.T) {
 	assert.Contains(t, content, "visible answer")
 }
 
+func TestApp_ExportDialog_OnlyReasoningParts_ExcludeThinking_EmptyAssistant(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	sess := session.New(t.TempDir())
+	app.SetSession(sess)
+	app.SetAgent(agent.BuildAgent())
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+
+	// Add assistant entry with ONLY reasoning parts (no text)
+	a.chat.Clear()
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "question"})
+	a.chat.AddEntry(components.ChatEntry{
+		Role: components.RoleAssistant,
+		Parts: []components.MessagePart{
+			{Type: components.PartReasoning, Content: "only thinking"},
+		},
+	})
+
+	// Export with includeThinking disabled
+	model, _ = a.Update(components.InputSubmitMsg{Value: "/export"})
+	a = model.(App)
+	a.exportDialog.includeThinking = false
+	a.exportDialog.filename = "reasoning-only-export.md"
+	a.exportDialog.focusedField = 3
+
+	model, _ = a.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	a = model.(App)
+
+	data, err := os.ReadFile(filepath.Join(sess.WorkDir, "reasoning-only-export.md"))
+	require.NoError(t, err)
+	content := string(data)
+	assert.NotContains(t, content, "only thinking", "reasoning-only entry should not leak thinking content")
+	assert.Contains(t, content, "question")
+}
+
 // Ensure unused imports don't cause issues
 var _ = provider.ModelInfo{}

--- a/internal/tui/dialog_export_test.go
+++ b/internal/tui/dialog_export_test.go
@@ -429,5 +429,43 @@ func TestApp_ExportDialog_OnlyReasoningParts_ExcludeThinking_EmptyAssistant(t *t
 	assert.Contains(t, content, "question")
 }
 
+func TestApp_ExportDialog_SkippedEntries_ShowsWarningToast(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	sess := session.New(t.TempDir())
+	app.SetSession(sess)
+	app.SetAgent(agent.BuildAgent())
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+
+	a.chat.Clear()
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "hello"})
+	// Add an entry with an unknown role — should be skipped during export
+	a.chat.AddEntry(components.ChatEntry{Role: "future_role", Content: "unknown"})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleAssistant, Content: "world"})
+
+	model, _ = a.Update(components.InputSubmitMsg{Value: "/export"})
+	a = model.(App)
+	a.exportDialog.filename = "skipped-export.md"
+	a.exportDialog.focusedField = 3
+
+	model, _ = a.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	a = model.(App)
+
+	toast := a.toasts.Current()
+	require.NotNil(t, toast, "should show toast")
+	assert.Contains(t, toast.Message, "skipped", "toast should mention skipped entries")
+
+	// Verify the file was still written
+	data, err := os.ReadFile(filepath.Join(sess.WorkDir, "skipped-export.md"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "hello")
+	assert.Contains(t, string(data), "world")
+	assert.NotContains(t, string(data), "unknown", "skipped entry content should not appear")
+}
+
 // Ensure unused imports don't cause issues
 var _ = provider.ModelInfo{}

--- a/internal/tui/dialog_sessions.go
+++ b/internal/tui/dialog_sessions.go
@@ -187,13 +187,15 @@ func (a *App) rebuildChatFromSession() {
 		switch rec.Message.Role {
 		case provider.RoleUser:
 			a.chat.AddEntry(components.ChatEntry{
-				Role:    components.RoleUser,
-				Content: rec.Message.Content,
+				Role:      components.RoleUser,
+				Content:   rec.Message.Content,
+				CreatedAt: rec.CreatedAt,
 			})
 		case provider.RoleAssistant:
 			a.chat.AddEntry(components.ChatEntry{
-				Role:    components.RoleAssistant,
-				Content: rec.Message.Content,
+				Role:      components.RoleAssistant,
+				Content:   rec.Message.Content,
+				CreatedAt: rec.CreatedAt,
 			})
 		case provider.RoleTool:
 			a.chat.AddEntry(components.ChatEntry{
@@ -202,6 +204,7 @@ func (a *App) rebuildChatFromSession() {
 				ToolID:     rec.Message.ToolCallID,
 				ToolName:   toolNames[rec.Message.ToolCallID],
 				ToolStatus: components.StatusSuccess,
+				CreatedAt:  rec.CreatedAt,
 			})
 		case provider.RoleSystem:
 			// System prompt messages are set separately; not displayed in chat.

--- a/internal/tui/dialog_sessions.go
+++ b/internal/tui/dialog_sessions.go
@@ -173,7 +173,17 @@ func (a *App) rebuildChatFromSession() {
 	if a.session == nil {
 		return
 	}
-	for _, rec := range a.session.Records() {
+	records := a.session.Records()
+
+	// Build callID→toolName index once to avoid O(n²) lookup per tool result.
+	toolNames := make(map[string]string)
+	for _, rec := range records {
+		for _, tc := range rec.Message.ToolCalls {
+			toolNames[tc.ID] = tc.Name
+		}
+	}
+
+	for _, rec := range records {
 		switch rec.Message.Role {
 		case provider.RoleUser:
 			a.chat.AddEntry(components.ChatEntry{
@@ -190,8 +200,13 @@ func (a *App) rebuildChatFromSession() {
 				Role:       components.RoleTool,
 				Content:    rec.Message.Content,
 				ToolID:     rec.Message.ToolCallID,
+				ToolName:   toolNames[rec.Message.ToolCallID],
 				ToolStatus: components.StatusSuccess,
 			})
+		case provider.RoleSystem:
+			// System prompt messages are set separately; not displayed in chat.
+		default:
+			store.LogErrorf("sessions: unhandled role %q in rebuildChatFromSession", rec.Message.Role)
 		}
 	}
 }

--- a/internal/tui/dialog_sessions_test.go
+++ b/internal/tui/dialog_sessions_test.go
@@ -429,6 +429,68 @@ func TestApp_SessionsLoadedMsg_WithError(t *testing.T) {
 	assert.NotNil(t, toast, "should show error toast")
 }
 
+func TestApp_RebuildChat_RecoverToolNames(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RIPCODE_DIR", dir)
+
+	sess := session.New(t.TempDir())
+	sess.AddUser("read main.go")
+	sess.AddAssistant("", []provider.ToolCall{{ID: "tc1", Name: "read", Args: `{"path":"main.go"}`}}, nil)
+	sess.AddToolResult("tc1", "package main\n")
+	require.NoError(t, store.Save(sess))
+
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	app.SetSession(session.New(t.TempDir()))
+	app.SetAgent(agent.BuildAgent())
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+
+	model, _ = a.resumeSession(sess.ID)
+	a = model.(App)
+
+	entries := a.chat.Entries()
+	var toolEntry *components.ChatEntry
+	for i := range entries {
+		if entries[i].Role == components.RoleTool {
+			toolEntry = &entries[i]
+			break
+		}
+	}
+	require.NotNil(t, toolEntry, "should have a tool entry")
+	assert.Equal(t, "read", toolEntry.ToolName, "tool name should be recovered from assistant ToolCalls")
+	assert.Equal(t, "tc1", toolEntry.ToolID)
+}
+
+func TestApp_RebuildChat_SkipsSystemMessages(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RIPCODE_DIR", dir)
+
+	sess := session.New(t.TempDir())
+	sess.AddUser("hello")
+	sess.AddAssistant("world", nil, nil)
+	require.NoError(t, store.Save(sess))
+
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	app.SetSession(session.New(t.TempDir()))
+	app.SetAgent(agent.BuildAgent())
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+
+	model, _ = a.resumeSession(sess.ID)
+	a = model.(App)
+
+	entries := a.chat.Entries()
+	for _, e := range entries {
+		assert.NotEqual(t, components.RoleSystem, e.Role, "system messages should not appear in chat")
+	}
+}
+
 func TestApp_SessionsLoadedMsg_WithError_ClearsStaleEntries(t *testing.T) {
 	app := makeSessionApp(t)
 	model, _ := app.Update(components.InputSubmitMsg{Value: "/sessions"})

--- a/internal/tui/dialog_sessions_test.go
+++ b/internal/tui/dialog_sessions_test.go
@@ -491,6 +491,38 @@ func TestApp_RebuildChat_SkipsSystemMessages(t *testing.T) {
 	}
 }
 
+func TestApp_RebuildChat_CarriesRecordTimestamps(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RIPCODE_DIR", dir)
+
+	sess := session.New(t.TempDir())
+	sess.AddUser("u1")
+	sess.AddAssistant("a1", []provider.ToolCall{{ID: "tc1", Name: "read", Args: `{"path":"main.go"}`}}, nil)
+	sess.AddToolResult("tc1", "tool output")
+	records := sess.Records()
+	require.Len(t, records, 3)
+	require.NoError(t, store.Save(sess))
+
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	app.SetSession(session.New(t.TempDir()))
+	app.SetAgent(agent.BuildAgent())
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+
+	model, _ = a.resumeSession(sess.ID)
+	a = model.(App)
+
+	entries := a.chat.Entries()
+	require.Len(t, entries, len(records))
+
+	assert.True(t, entries[0].CreatedAt.Equal(records[0].CreatedAt), "user entry timestamp should match session record")
+	assert.True(t, entries[1].CreatedAt.Equal(records[1].CreatedAt), "assistant entry timestamp should match session record")
+	assert.True(t, entries[2].CreatedAt.Equal(records[2].CreatedAt), "tool entry timestamp should match session record")
+}
+
 func TestApp_SessionsLoadedMsg_WithError_ClearsStaleEntries(t *testing.T) {
 	app := makeSessionApp(t)
 	model, _ := app.Update(components.InputSubmitMsg{Value: "/sessions"})

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -146,7 +146,7 @@ func listenForEvents(ch <-chan agent.Event) tea.Cmd {
 	return func() tea.Msg {
 		event, ok := <-ch
 		if !ok {
-			return AgentEventMsg{Event: agent.Event{Type: agent.EventDone}}
+			return AgentEventMsg{Event: agent.NewDoneEvent(nil)}
 		}
 		return AgentEventMsg{Event: event}
 	}

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -24,6 +24,9 @@ func (a App) handleAgentEvent(event agent.Event) (tea.Model, tea.Cmd) {
 		return a, listenForEvents(a.eventCh)
 
 	case agent.EventToolStart:
+		// Tool boundaries split assistant output into distinct messages.
+		// This prevents pre-tool deltas from being merged into post-tool content.
+		a.chat.CommitStream()
 		if event.Tool != nil {
 			a.chat.AddEntry(components.ChatEntry{
 				Role:       components.RoleTool,
@@ -116,9 +119,11 @@ func (a App) handleAgentEvent(event agent.Event) (tea.Model, tea.Cmd) {
 			})
 		}
 		return a, nil
-	}
 
-	return a, nil
+	default:
+		store.LogError(fmt.Sprintf("events: unhandled agent event type %d", event.Type), nil)
+		return a, nil
+	}
 }
 
 // toolSummary extracts a short summary from tool args.

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -121,7 +121,7 @@ func (a App) handleAgentEvent(event agent.Event) (tea.Model, tea.Cmd) {
 		return a, nil
 
 	default:
-		store.LogError(fmt.Sprintf("events: unhandled agent event type %d", event.Type), nil)
+		store.LogErrorf("events: unhandled agent event type %d", event.Type)
 		return a, nil
 	}
 }

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -122,7 +122,7 @@ func (a App) handleAgentEvent(event agent.Event) (tea.Model, tea.Cmd) {
 
 	default:
 		store.LogErrorf("events: unhandled agent event type %d", event.Type)
-		return a, nil
+		return a, listenForEvents(a.eventCh)
 	}
 }
 

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -16,7 +16,11 @@ import (
 func (a App) handleAgentEvent(event agent.Event) (tea.Model, tea.Cmd) {
 	switch event.Type {
 	case agent.EventContentDelta:
-		a.chat.StreamContent(event.Content)
+		a.chat.StreamPart(components.PartText, event.Content)
+		return a, listenForEvents(a.eventCh)
+
+	case agent.EventReasoningDelta:
+		a.chat.StreamPart(components.PartReasoning, event.Content)
 		return a, listenForEvents(a.eventCh)
 
 	case agent.EventToolStart:

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -175,9 +175,9 @@ func TestApp_UnknownEventType_GracefullyIgnored(t *testing.T) {
 	})
 	a := model.(App)
 
-	// Should not panic, should not crash
+	// Should not panic, should not crash, and should continue listening
 	assert.True(t, a.streaming, "streaming should remain active after unknown event")
-	assert.Nil(t, cmd, "unknown event should not return a command")
+	assert.NotNil(t, cmd, "unknown event must continue listening for events")
 }
 
 // --- Reasoning Event tests ---

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stephenbrandon/ripcode/internal/session"
 	"github.com/stephenbrandon/ripcode/internal/store"
 	"github.com/stephenbrandon/ripcode/internal/tool"
+	"github.com/stephenbrandon/ripcode/internal/tui/components"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -160,6 +161,25 @@ func TestApp_AgentEventDone_PersistsSession(t *testing.T) {
 	assert.Equal(t, sess.ID, loaded.ID)
 }
 
+func TestApp_UnknownEventType_GracefullyIgnored(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	ch := make(chan agent.Event, 1)
+	app.streaming = true
+	app.state = StateSession
+	app.eventCh = ch
+
+	// Use an event type value beyond the known range
+	model, cmd := app.Update(AgentEventMsg{
+		Event: agent.Event{Type: agent.EventType(99), Content: "future event"},
+	})
+	a := model.(App)
+
+	// Should not panic, should not crash
+	assert.True(t, a.streaming, "streaming should remain active after unknown event")
+	assert.Nil(t, cmd, "unknown event should not return a command")
+}
+
 // --- Reasoning Event tests ---
 
 func TestApp_ReasoningDelta_ContinuesListening(t *testing.T) {
@@ -216,6 +236,49 @@ func TestApp_ReasoningDelta_StreamsPart(t *testing.T) {
 
 	view := a.chat.View()
 	assert.Contains(t, view, "deep thought")
+}
+
+func TestApp_ToolStart_SegmentsAssistantStreamAcrossToolPhase(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.state = StateSession
+	ch := make(chan agent.Event, 1)
+	app.streaming = true
+	app.eventCh = ch
+
+	model, _ := app.Update(AgentEventMsg{
+		Event: agent.Event{Type: agent.EventContentDelta, Content: "before "},
+	})
+	a := model.(App)
+
+	model, _ = a.Update(AgentEventMsg{
+		Event: agent.Event{
+			Type: agent.EventToolStart,
+			Tool: &agent.ToolEvent{ID: "1", Name: "read", Args: `{"file_path":"README.md"}`},
+		},
+	})
+	a = model.(App)
+
+	model, _ = a.Update(AgentEventMsg{
+		Event: agent.Event{Type: agent.EventContentDelta, Content: "after"},
+	})
+	a = model.(App)
+
+	model, _ = a.Update(AgentEventMsg{
+		Event: agent.Event{Type: agent.EventDone},
+	})
+	a = model.(App)
+
+	var assistant []components.ChatEntry
+	for _, e := range a.chat.Entries() {
+		if e.Role == components.RoleAssistant {
+			assistant = append(assistant, e)
+		}
+	}
+
+	require.Len(t, assistant, 2)
+	assert.Equal(t, "before ", assistant[0].Content)
+	assert.Equal(t, "after", assistant[1].Content)
 }
 
 // --- Modified Files Tracking tests ---

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -160,6 +160,64 @@ func TestApp_AgentEventDone_PersistsSession(t *testing.T) {
 	assert.Equal(t, sess.ID, loaded.ID)
 }
 
+// --- Reasoning Event tests ---
+
+func TestApp_ReasoningDelta_ContinuesListening(t *testing.T) {
+	app := NewApp()
+	ch := make(chan agent.Event, 1)
+	app.streaming = true
+	app.state = StateSession
+	app.eventCh = ch
+
+	model, cmd := app.Update(AgentEventMsg{
+		Event: agent.Event{Type: agent.EventReasoningDelta, Content: "thinking"},
+	})
+	a := model.(App)
+
+	assert.True(t, a.streaming)
+	assert.NotNil(t, cmd, "non-terminal event must return a listen command")
+}
+
+func TestApp_ContentDelta_UsesStreamPart(t *testing.T) {
+	app := NewApp()
+	app.state = StateSession
+	ch := make(chan agent.Event, 1)
+	app.streaming = true
+	app.eventCh = ch
+
+	// Size the chat so rendering works
+	app.chat.SetSize(80, 20)
+
+	model, _ := app.Update(AgentEventMsg{
+		Event: agent.Event{Type: agent.EventContentDelta, Content: "hello"},
+	})
+	a := model.(App)
+
+	// Should show in view (via StreamPart, not legacy StreamContent)
+	view := a.chat.View()
+	assert.Contains(t, view, "hello")
+}
+
+func TestApp_ReasoningDelta_StreamsPart(t *testing.T) {
+	app := NewApp()
+	app.state = StateSession
+	ch := make(chan agent.Event, 1)
+	app.streaming = true
+	app.eventCh = ch
+
+	// Size the chat and enable thinking
+	app.chat.SetSize(80, 20)
+	app.chat.SetShowThinking(true)
+
+	model, _ := app.Update(AgentEventMsg{
+		Event: agent.Event{Type: agent.EventReasoningDelta, Content: "deep thought"},
+	})
+	a := model.(App)
+
+	view := a.chat.View()
+	assert.Contains(t, view, "deep thought")
+}
+
 // --- Modified Files Tracking tests ---
 
 func TestApp_ModifiedFiles_TracksWriteEvent(t *testing.T) {

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -281,6 +281,54 @@ func TestApp_ToolStart_SegmentsAssistantStreamAcrossToolPhase(t *testing.T) {
 	assert.Equal(t, "after", assistant[1].Content)
 }
 
+func TestApp_CancelDuringReasoningPart_CommitsPartialSafely(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.state = StateSession
+	ch := make(chan agent.Event, 1)
+	app.streaming = true
+	app.eventCh = ch
+	app.chat.SetSize(80, 20)
+	app.chat.SetShowThinking(true)
+
+	// Stream reasoning, then text
+	model, _ := app.Update(AgentEventMsg{
+		Event: agent.NewReasoningEvent("thinking hard"),
+	})
+	a := model.(App)
+
+	model, _ = a.Update(AgentEventMsg{
+		Event: agent.NewContentEvent("partial answer"),
+	})
+	a = model.(App)
+
+	// Cancel mid-stream (Esc during streaming)
+	a.cancel = func() {} // no-op cancel
+	model, _ = a.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	a = model.(App)
+
+	assert.False(t, a.streaming, "should stop streaming")
+
+	// CommitStream should have been called — verify entries are sane
+	entries := a.chat.Entries()
+	// Should have committed the partial stream with both reasoning and text
+	var assistant []components.ChatEntry
+	for _, e := range entries {
+		if e.Role == components.RoleAssistant {
+			assistant = append(assistant, e)
+		}
+	}
+	if len(assistant) > 0 {
+		last := assistant[len(assistant)-1]
+		// Either has Parts with both types or Content with the text
+		if len(last.Parts) > 0 {
+			assert.NoError(t, last.Valid(), "committed entry with parts should be valid")
+		} else if last.Content != "" {
+			assert.NotEmpty(t, last.Content)
+		}
+	}
+}
+
 // --- Modified Files Tracking tests ---
 
 func TestApp_ModifiedFiles_TracksWriteEvent(t *testing.T) {

--- a/internal/tui/inline.go
+++ b/internal/tui/inline.go
@@ -89,10 +89,17 @@ func (a App) inlineEntries() []inlineEntry {
 		}
 		out := make([]inlineEntry, 0, len(commands))
 		for _, cmd := range commands {
+			desc := cmd.Description
+			if cmd.Keybind != "" {
+				desc += "  [" + cmd.Keybind + "]"
+			}
+			if len(cmd.Aliases) > 0 {
+				desc += "  (also: /" + strings.Join(cmd.Aliases, ", /") + ")"
+			}
 			out = append(out, inlineEntry{
 				Display:     "/" + cmd.Name,
 				Insert:      "/" + cmd.Name,
-				Description: cmd.Description,
+				Description: desc,
 				Execute:     cmd.Execute,
 			})
 		}

--- a/internal/tui/inline_test.go
+++ b/internal/tui/inline_test.go
@@ -329,4 +329,7 @@ func TestApp_InlineFileAutocomplete_MultibytePrefixReplacement(t *testing.T) {
 
 	assert.False(t, a.inline.open)
 	assert.Equal(t, "日本 @main.go ", a.input.Value())
+	// Cursor should be positioned after the inserted "@main.go " (rune index 12)
+	// 日(1) 本(2) ' '(3) @(4) m(5) a(6) i(7) n(8) .(9) g(10) o(11) ' '(12)
+	assert.Equal(t, 12, a.input.CursorOffset(), "cursor should be at end of inserted text")
 }

--- a/internal/tui/inline_test.go
+++ b/internal/tui/inline_test.go
@@ -176,6 +176,114 @@ func TestUpdateInlineSuggestions_CursorAfterMention(t *testing.T) {
 	assert.False(t, app.inline.open, "space after @mention should close inline suggestions")
 }
 
+// --- Sub-Phase 5.8: Rich / autocomplete ---
+
+func TestInlineEntries_ShowsKeybindHint(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+
+	// Open inline with "/rename" filter
+	app.inline.open = true
+	app.inline.mode = inlineModeCommand
+	app.inline.query = "rename"
+
+	entries := app.inlineEntries()
+	var found bool
+	for _, e := range entries {
+		if e.Display == "/rename" {
+			found = true
+			assert.Contains(t, e.Description, "[Ctrl+R]", "should show keybind hint")
+			break
+		}
+	}
+	assert.True(t, found, "/rename should appear in results")
+}
+
+func TestInlineEntries_ShowsAliasHint(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+
+	// Open inline with "/thinking" filter
+	app.inline.open = true
+	app.inline.mode = inlineModeCommand
+	app.inline.query = "thinking"
+
+	entries := app.inlineEntries()
+	var found bool
+	for _, e := range entries {
+		if e.Display == "/thinking" {
+			found = true
+			assert.Contains(t, e.Description, "(also: /toggle-thinking)", "should show alias info")
+			break
+		}
+	}
+	assert.True(t, found, "/thinking should appear in results")
+}
+
+func TestInlineEntries_ShowsKeybindAndAlias(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+
+	// Open inline with "/stash" filter — has keybind Ctrl+S and no aliases?
+	// Let's check a command with both: stash has Keybind: "Ctrl+S" but no aliases
+	// Let's use the "new" command which has alias "clear" but no keybind
+	app.inline.open = true
+	app.inline.mode = inlineModeCommand
+	app.inline.query = "new"
+
+	entries := app.inlineEntries()
+	var found bool
+	for _, e := range entries {
+		if e.Display == "/new" {
+			found = true
+			assert.Contains(t, e.Description, "(also: /clear)", "should show alias")
+			break
+		}
+	}
+	assert.True(t, found, "/new should appear in results")
+}
+
+func TestInlineEntries_AliasMatchReturnsCommand(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+
+	// Typing "toggle" should match /thinking via alias "toggle-thinking"
+	app.inline.open = true
+	app.inline.mode = inlineModeCommand
+	app.inline.query = "toggle"
+
+	entries := app.inlineEntries()
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Display)
+	}
+	assert.Contains(t, names, "/thinking", "alias toggle-thinking should match")
+	assert.Contains(t, names, "/timestamps", "alias toggle-timestamps should match")
+}
+
+func TestInlineEntries_NoHintWhenNone(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+
+	// /exit has aliases but no keybind
+	app.inline.open = true
+	app.inline.mode = inlineModeCommand
+	app.inline.query = "exit"
+
+	entries := app.inlineEntries()
+	var found bool
+	for _, e := range entries {
+		if e.Display == "/exit" {
+			found = true
+			// Should show aliases but no brackets (no keybind)
+			assert.NotContains(t, e.Description, "[")
+			assert.Contains(t, e.Description, "(also: /quit, /q)")
+			break
+		}
+	}
+	assert.True(t, found, "/exit should appear in results")
+}
+
 func TestApp_InlineFileAutocomplete_MultibytePrefixReplacement(t *testing.T) {
 	workDir := t.TempDir()
 	err := os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package main"), 0o644)

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -294,6 +294,11 @@ func (a App) handleLeaderKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		a.agentDialog.query = ""
 		a.agentDialog.selected = 0
 		return a, nil
+	case msg.Code == 'h':
+		if cmd := a.cmdRegistry.Get("conceal"); cmd != nil && cmd.Handler != nil {
+			return a, cmd.Handler(&a)
+		}
+		return a, nil
 	default:
 		return a, nil
 	}

--- a/internal/tui/registry.go
+++ b/internal/tui/registry.go
@@ -35,6 +35,7 @@ type Command struct {
 	Execute     bool
 	Disabled    func() bool
 	Handler     func(a *App) tea.Cmd
+	searchText  string // pre-computed lowercase haystack for Filter()
 }
 
 func (c *Command) isDisabled() bool {
@@ -59,6 +60,7 @@ func (r *CommandRegistry) Register(cmd Command) {
 		panic(fmt.Sprintf("duplicate command name: %s", cmd.Name))
 	}
 	c := cmd // copy
+	c.searchText = strings.ToLower(c.Name + " " + strings.Join(c.Aliases, " ") + " " + c.Title + " " + c.Description)
 	r.byName[c.Name] = &c
 	for _, alias := range c.Aliases {
 		if _, ok := r.byName[alias]; ok {
@@ -109,7 +111,7 @@ func (r *CommandRegistry) ByCategory() map[CommandCategory][]*Command {
 	return out
 }
 
-// Filter returns commands matching the query against name, title, and description.
+// Filter returns commands matching the query against name, aliases, title, and description.
 func (r *CommandRegistry) Filter(query string) []*Command {
 	q := strings.ToLower(strings.TrimSpace(query))
 	if q == "" {
@@ -120,8 +122,7 @@ func (r *CommandRegistry) Filter(query string) []*Command {
 		if c.Hidden || c.isDisabled() {
 			continue
 		}
-		haystack := strings.ToLower(c.Name + " " + c.Title + " " + c.Description)
-		if strings.Contains(haystack, q) {
+		if strings.Contains(c.searchText, q) {
 			out = append(out, c)
 		}
 	}

--- a/internal/tui/registry_test.go
+++ b/internal/tui/registry_test.go
@@ -105,3 +105,56 @@ func TestRegistry_Register_DuplicateName_Panics(t *testing.T) {
 		r.Register(Command{Name: "help", Handler: dummyHandler})
 	})
 }
+
+// --- Sub-Phase 5.8: Filter matches aliases ---
+
+func TestRegistry_Filter_MatchesAlias(t *testing.T) {
+	r := NewCommandRegistry()
+	r.Register(Command{
+		Name:        "thinking",
+		Aliases:     []string{"toggle-thinking"},
+		Description: "Show reasoning blocks",
+		Handler:     dummyHandler,
+	})
+	r.Register(Command{
+		Name:        "exit",
+		Description: "Quit ripcode",
+		Handler:     dummyHandler,
+	})
+
+	// "toggle-thinking" only appears in the alias, not name/title/description
+	matches := r.Filter("toggle-thinking")
+	assert.Len(t, matches, 1)
+	assert.Equal(t, "thinking", matches[0].Name)
+}
+
+func TestRegistry_Filter_MatchesPartialAlias(t *testing.T) {
+	r := NewCommandRegistry()
+	r.Register(Command{
+		Name:        "foo",
+		Title:       "Foo",
+		Aliases:     []string{"bar-baz"},
+		Description: "Does something",
+		Handler:     dummyHandler,
+	})
+
+	// "bar" only appears in alias "bar-baz", not in name/title/description
+	matches := r.Filter("bar")
+	assert.Len(t, matches, 1)
+	assert.Equal(t, "foo", matches[0].Name)
+}
+
+func TestRegistry_Filter_AliasNotInDescription(t *testing.T) {
+	r := NewCommandRegistry()
+	r.Register(Command{
+		Name:        "new",
+		Aliases:     []string{"reset"},
+		Description: "Start fresh session",
+		Handler:     dummyHandler,
+	})
+
+	// "reset" only appears in alias, not in name/title/description
+	matches := r.Filter("reset")
+	assert.Len(t, matches, 1)
+	assert.Equal(t, "new", matches[0].Name)
+}

--- a/internal/tui/submit_test.go
+++ b/internal/tui/submit_test.go
@@ -420,6 +420,26 @@ func TestApp_CopyCommand_MixedPartsNotTreatedAsEmpty(t *testing.T) {
 	assert.NotContains(t, toast.Message, "No assistant response")
 }
 
+func TestApp_CopyCommand_AllReasoningEntry_IsCopyable(t *testing.T) {
+	a := makeSessionApp(t)
+	a.chat.Clear()
+	// Add an entry with only reasoning parts (no text parts)
+	a.chat.AddEntry(components.ChatEntry{
+		Role: components.RoleAssistant,
+		Parts: []components.MessagePart{
+			{Type: components.PartReasoning, Content: "deep reasoning only"},
+		},
+	})
+
+	model, cmd := a.Update(components.InputSubmitMsg{Value: "/copy"})
+	a = model.(App)
+	assert.NotNil(t, cmd)
+	toast := a.toasts.Current()
+	assert.NotNil(t, toast)
+	// Should NOT warn about no response — CopyableContent() falls back to parts
+	assert.NotContains(t, toast.Message, "No assistant response")
+}
+
 func TestApp_CompactCommand_ShowsToast(t *testing.T) {
 	a := makeSessionAppWithHistory(t)
 	model, _ := a.Update(components.InputSubmitMsg{Value: "/compact"})

--- a/internal/tui/submit_test.go
+++ b/internal/tui/submit_test.go
@@ -205,13 +205,13 @@ func TestApp_SlashDetails_TogglesShowDetails(t *testing.T) {
 	a := model.(App)
 	a.state = StateSession
 
-	assert.False(t, a.showDetails)
+	assert.False(t, a.chat.ShowDetails())
 	model, _ = a.Update(components.InputSubmitMsg{Value: "/details"})
 	a = model.(App)
-	assert.True(t, a.showDetails)
+	assert.True(t, a.chat.ShowDetails())
 	model, _ = a.Update(components.InputSubmitMsg{Value: "/details"})
 	a = model.(App)
-	assert.False(t, a.showDetails)
+	assert.False(t, a.chat.ShowDetails())
 }
 
 func TestApp_SlashThinking_TogglesShowThinking(t *testing.T) {
@@ -225,10 +225,10 @@ func TestApp_SlashThinking_TogglesShowThinking(t *testing.T) {
 	a := model.(App)
 	a.state = StateSession
 
-	assert.False(t, a.showThinking)
+	assert.False(t, a.chat.ShowThinking())
 	model, _ = a.Update(components.InputSubmitMsg{Value: "/thinking"})
 	a = model.(App)
-	assert.True(t, a.showThinking)
+	assert.True(t, a.chat.ShowThinking())
 }
 
 func TestApp_SlashTimestamps_TogglesShowTimestamps(t *testing.T) {
@@ -242,10 +242,10 @@ func TestApp_SlashTimestamps_TogglesShowTimestamps(t *testing.T) {
 	a := model.(App)
 	a.state = StateSession
 
-	assert.False(t, a.showTimestamps)
+	assert.False(t, a.chat.ShowTimestamps())
 	model, _ = a.Update(components.InputSubmitMsg{Value: "/timestamps"})
 	a = model.(App)
-	assert.True(t, a.showTimestamps)
+	assert.True(t, a.chat.ShowTimestamps())
 }
 
 func TestApp_SlashRename_OpensDialog(t *testing.T) {
@@ -403,6 +403,21 @@ func TestApp_CopyCommand_ShowsSuccessToast(t *testing.T) {
 	// May succeed or fail depending on clipboard availability in test env
 	assert.NotNil(t, cmd)
 	assert.NotNil(t, a.toasts.Current())
+}
+
+func TestApp_CopyCommand_MixedPartsNotTreatedAsEmpty(t *testing.T) {
+	a := makeSessionApp(t)
+	a.chat.Clear()
+	a.chat.StreamPart(components.PartReasoning, "thinking")
+	a.chat.StreamPart(components.PartText, "visible answer")
+	a.chat.CommitStream()
+
+	model, cmd := a.Update(components.InputSubmitMsg{Value: "/copy"})
+	a = model.(App)
+	assert.NotNil(t, cmd)
+	toast := a.toasts.Current()
+	assert.NotNil(t, toast)
+	assert.NotContains(t, toast.Message, "No assistant response")
 }
 
 func TestApp_CompactCommand_ShowsToast(t *testing.T) {

--- a/internal/tui/toggles_test.go
+++ b/internal/tui/toggles_test.go
@@ -1,0 +1,348 @@
+package tui
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/stephenbrandon/ripcode/internal/tui/components"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- Sub-Phase 5.4: Thinking visibility toggle ---
+
+func TestThinkingToggle_PropagatestoChat(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+
+	cmd := app.cmdRegistry.Get("thinking")
+	assert.NotNil(t, cmd)
+
+	// Initially off
+	assert.False(t, app.chat.ShowThinking())
+
+	// Toggle on
+	cmd.Handler(&app)
+	assert.True(t, app.chat.ShowThinking())
+
+	// Toggle off
+	cmd.Handler(&app)
+	assert.False(t, app.chat.ShowThinking())
+}
+
+func TestThinkingToggle_ReasoningRendersWhenEnabled(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+	app.chat.Clear()
+	app.chat.SetSize(80, 20)
+
+	// Add entry with reasoning parts
+	app.chat.AddEntry(components.ChatEntry{
+		Role: components.RoleAssistant,
+		Parts: []components.MessagePart{
+			{Type: components.PartReasoning, Content: "deep thought"},
+			{Type: components.PartText, Content: "answer"},
+		},
+	})
+
+	// Thinking off — reasoning hidden
+	view := app.chat.View()
+	assert.NotContains(t, view, "deep thought")
+	assert.Contains(t, view, "answer")
+
+	// Toggle on
+	app.chat.SetShowThinking(true)
+	view = app.chat.View()
+	assert.Contains(t, view, "deep thought")
+	assert.Contains(t, view, "answer")
+}
+
+func TestThinkingToggle_ReasoningRedacted(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+	app.chat.Clear()
+	app.chat.SetSize(80, 20)
+	app.chat.SetShowThinking(true)
+
+	app.chat.AddEntry(components.ChatEntry{
+		Role: components.RoleAssistant,
+		Parts: []components.MessagePart{
+			{Type: components.PartReasoning, Content: "[REDACTED]"},
+			{Type: components.PartText, Content: "visible"},
+		},
+	})
+
+	view := app.chat.View()
+	assert.Contains(t, view, "[REDACTED]")
+	assert.Contains(t, view, "visible")
+}
+
+// --- Sub-Phase 5.5: Tool details toggle ---
+
+func TestDetailsToggle_PropagatesToChat(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+
+	cmd := app.cmdRegistry.Get("details")
+	assert.NotNil(t, cmd)
+
+	assert.False(t, app.chat.ShowDetails())
+
+	cmd.Handler(&app)
+	assert.True(t, app.chat.ShowDetails())
+
+	cmd.Handler(&app)
+	assert.False(t, app.chat.ShowDetails())
+}
+
+func TestDetailsToggle_ToolEntryExpandsWhenEnabled(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 20)
+	c.SetShowDetails(true)
+
+	c.AddEntry(components.ChatEntry{
+		Role:       components.RoleTool,
+		Content:    "line1\nline2\nline3",
+		ToolName:   "bash",
+		ToolStatus: components.StatusSuccess,
+		ToolID:     "t1",
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "line1")
+	assert.Contains(t, view, "line2")
+	assert.Contains(t, view, "line3")
+}
+
+func TestDetailsToggle_ToolEntryCollapsedWhenDisabled(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 20)
+	c.SetShowDetails(false) // default
+
+	c.AddEntry(components.ChatEntry{
+		Role:       components.RoleTool,
+		Content:    "line1\nline2\nline3",
+		ToolName:   "bash",
+		ToolStatus: components.StatusSuccess,
+		ToolID:     "t1",
+	})
+
+	view := c.View()
+	// Should show summary line only, not the full output
+	assert.Contains(t, view, "bash")
+	assert.NotContains(t, view, "line2", "details should be hidden when showDetails is false")
+}
+
+func TestDetailsToggle_PendingToolAlwaysSingleLine(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 20)
+	c.SetShowDetails(true)
+
+	c.AddEntry(components.ChatEntry{
+		Role:       components.RoleTool,
+		Content:    "waiting\nmore output",
+		ToolName:   "bash",
+		ToolStatus: components.StatusPending,
+		ToolID:     "t1",
+	})
+
+	view := c.View()
+	assert.NotContains(t, view, "more output", "pending tool should not expand")
+}
+
+func TestDetailsToggle_ErrorToolShowsErrorRegardless(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 20)
+	c.SetShowDetails(false) // details off
+
+	c.AddEntry(components.ChatEntry{
+		Role:       components.RoleTool,
+		Content:    "error message",
+		ToolName:   "write",
+		ToolStatus: components.StatusError,
+		ToolID:     "t1",
+	})
+
+	view := c.View()
+	// Error tool should show the error indicator
+	assert.Contains(t, view, "✗")
+}
+
+// --- Sub-Phase 5.6: Timestamps toggle ---
+
+func TestTimestampsToggle_PropagatesToChat(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+
+	cmd := app.cmdRegistry.Get("timestamps")
+	assert.NotNil(t, cmd)
+
+	assert.False(t, app.chat.ShowTimestamps())
+
+	cmd.Handler(&app)
+	assert.True(t, app.chat.ShowTimestamps())
+
+	cmd.Handler(&app)
+	assert.False(t, app.chat.ShowTimestamps())
+}
+
+func TestTimestamps_UserMessage_ShowsTimestampWhenEnabled(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 20)
+	c.SetShowTimestamps(true)
+
+	ts := time.Date(2024, 3, 15, 14, 30, 0, 0, time.Local)
+	c.AddEntry(components.ChatEntry{
+		Role:      components.RoleUser,
+		Content:   "hello",
+		CreatedAt: ts,
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "2:30 PM")
+	assert.Contains(t, view, "hello")
+}
+
+func TestTimestamps_Hidden_WhenFlagDisabled(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 20)
+	c.SetShowTimestamps(false)
+
+	ts := time.Date(2024, 3, 15, 14, 30, 0, 0, time.Local)
+	c.AddEntry(components.ChatEntry{
+		Role:      components.RoleUser,
+		Content:   "hello",
+		CreatedAt: ts,
+	})
+
+	view := c.View()
+	assert.NotContains(t, view, "2:30 PM")
+	assert.Contains(t, view, "hello")
+}
+
+func TestTimestamps_Hidden_WhenCreatedAtZero(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 20)
+	c.SetShowTimestamps(true)
+
+	c.AddEntry(components.ChatEntry{
+		Role:    components.RoleUser,
+		Content: "no time",
+	})
+
+	view := c.View()
+	// Should not crash and should render without timestamp
+	assert.Contains(t, view, "no time")
+}
+
+func TestTimestamps_AssistantMessage_ShowsTimestamp(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 20)
+	c.SetShowTimestamps(true)
+
+	ts := time.Date(2024, 3, 15, 9, 5, 0, 0, time.Local)
+	c.AddEntry(components.ChatEntry{
+		Role:      components.RoleAssistant,
+		Content:   "response",
+		CreatedAt: ts,
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "9:05 AM")
+	assert.Contains(t, view, "response")
+}
+
+func TestTimestamps_AssistantParts_ShowsTimestamp(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 20)
+	c.SetShowTimestamps(true)
+	c.SetShowThinking(true)
+
+	ts := time.Date(2024, 6, 10, 15, 45, 0, 0, time.Local)
+	c.AddEntry(components.ChatEntry{
+		Role:      components.RoleAssistant,
+		CreatedAt: ts,
+		Parts: []components.MessagePart{
+			{Type: components.PartReasoning, Content: "thinking"},
+			{Type: components.PartText, Content: "answer"},
+		},
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "3:45 PM")
+	assert.Contains(t, view, "answer")
+}
+
+// --- Sub-Phase 5.7: Code block concealment ---
+
+func TestConcealCommand_Registered(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+
+	cmd := app.cmdRegistry.Get("conceal")
+	assert.NotNil(t, cmd)
+	assert.True(t, cmd.Hidden, "conceal should be a hidden command")
+}
+
+func TestConcealCommand_TogglesShowCodeBlocks(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+
+	assert.True(t, app.chat.ShowCodeBlocks(), "default should be true")
+
+	cmd := app.cmdRegistry.Get("conceal")
+	cmd.Handler(&app)
+	assert.False(t, app.chat.ShowCodeBlocks())
+
+	cmd.Handler(&app)
+	assert.True(t, app.chat.ShowCodeBlocks())
+}
+
+func TestLeaderH_DispatchesToConceal(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+	app.leaderPending = true
+
+	assert.True(t, app.chat.ShowCodeBlocks())
+
+	model, _ := app.Update(tea.KeyPressMsg{Code: 'h'})
+	a := model.(App)
+
+	assert.False(t, a.leaderPending, "leader should be consumed")
+	assert.False(t, a.chat.ShowCodeBlocks(), "should have toggled code blocks off")
+}
+
+func TestLeaderH_NoConcealCommand_NoOp(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := makeSessionApp(t)
+
+	// Remove the conceal command from registry to simulate it not existing
+	originalCodeBlocks := app.chat.ShowCodeBlocks()
+	app.cmdRegistry = NewCommandRegistry() // empty registry
+	app.leaderPending = true
+
+	model, cmd := app.Update(tea.KeyPressMsg{Code: 'h'})
+	a := model.(App)
+
+	assert.False(t, a.leaderPending, "leader should be consumed")
+	assert.Nil(t, cmd, "should produce no command")
+	assert.Equal(t, originalCodeBlocks, a.chat.ShowCodeBlocks(), "code block visibility should be unchanged")
+}
+
+func TestTimestamps_Format12Hour(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 20)
+	c.SetShowTimestamps(true)
+
+	// Test AM time
+	am := time.Date(2024, 1, 1, 0, 0, 0, 0, time.Local)
+	c.AddEntry(components.ChatEntry{
+		Role:      components.RoleUser,
+		Content:   "midnight",
+		CreatedAt: am,
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "12:00 AM")
+}


### PR DESCRIPTION
## Summary

Phase 5 PR1 — rendering fidelity and visibility controls for ripcode.

- **Part-based assistant messages**: `ChatEntry.Parts []MessagePart` with `PartText`/`PartReasoning` types. `StreamPart()` accumulates interleaved parts during streaming; `CommitStream()` finalizes. Backward compatible — `Content` string still used for simple entries.
- **OpenRouter reasoning SSE**: Parse `reasoning_details` from SSE deltas (`reasoning.text`, `reasoning.summary`, `reasoning.encrypted → [REDACTED]`). New `EventReasoningDelta` in provider and agent event types.
- **Agent loop propagation**: Reasoning events forwarded through agent loop to TUI. Reasoning is ephemeral (display-only, not persisted to session records).
- **Thinking toggle**: `/thinking` wires `showThinking` to chat rendering — reasoning parts render with dimmed italic style when enabled.
- **Tool details toggle**: `/details` expands/collapses tool output below summary line. Pending tools always single-line; errors always show indicator.
- **Timestamps toggle**: `/timestamps` shows 12-hour timestamps (`3:04 PM`) on user and assistant messages.
- **Code block concealment**: `ctrl+x h` / `/conceal` (hidden command) replaces fenced code blocks with `[code block hidden]`. State machine parser handles unclosed blocks; inline code unaffected.
- **Rich `/` autocomplete**: Alias matching in `Filter()`, keybind hints `[Ctrl+R]` and alias hints `(also: /toggle-thinking)` in inline suggestions.
- **Simplify pass**: Eliminated redundant `App↔Chat` state duplication (4 toggle flags), extracted `effectiveTheme()` helper, reasoning type constants, pre-computed registry search text.

## Test plan

- [x] `go test ./... -race -count=1` — 1012 tests passing
- [x] `go vet ./...` — clean
- [x] `go build -o bin/ripcode ./cmd/ripcode` — builds
- [ ] Manual smoke test with thinking model (e.g. `deepseek/deepseek-r1`): reasoning streams with dimmed italic style
- [ ] Manual test: `/thinking`, `/details`, `/timestamps`, `ctrl+x h` toggles work
- [ ] Manual test: `/` autocomplete shows aliases and keybinds
- [ ] Manual test: non-thinking model renders normally, all toggles still functional