### PR TITLE
Phase 6: Diff rendering, timeline badges, message actions, frecency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,28 +5,29 @@ go 1.25.0
 require (
 	charm.land/bubbletea/v2 v2.0.0
 	charm.land/lipgloss/v2 v2.0.0
+	github.com/atotto/clipboard v0.1.4
 	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/joho/godotenv v1.5.1
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/sahilm/fuzzy v0.1.1
 	github.com/stretchr/testify v1.11.1
 )
 
 require (
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-runewidth v0.0.20 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-runewidth v0.0.20 h1:WcT52H91ZUAwy8+HUkdM3THM6gXqXuLJi9O3rjcQQaQ=

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -32,6 +32,7 @@ type ToolEvent struct {
 	Args   string
 	Output string
 	Error  string
+	Diff   *tool.DiffInfo // optional, for write/edit tool results
 }
 
 // Event is a single event emitted by the agentic loop.
@@ -275,6 +276,7 @@ func (l *Loop) executeTool(ctx context.Context, tc provider.ToolCall, ch chan<- 
 		Args:   tc.Args,
 		Output: output,
 		Error:  errStr,
+		Diff:   result.Diff,
 	})
 }
 

--- a/internal/store/frecency.go
+++ b/internal/store/frecency.go
@@ -1,0 +1,133 @@
+package store
+
+import (
+	"math"
+	"sort"
+	"time"
+)
+
+const frecencyFile = "frecency.json"
+
+// maxFrecencyAge is the age beyond which entries are pruned on load.
+const maxFrecencyAge = 30 * 24 * time.Hour
+
+// frecencyHalfLife controls how quickly recency weight decays.
+// At 7 days since last use, the recency weight is 0.5.
+const frecencyHalfLife = 7.0
+
+// FileFrecency tracks file access patterns for frecency-based ranking.
+type FileFrecency struct {
+	Entries map[string]FrecencyEntry `json:"entries"`
+}
+
+// FrecencyEntry records usage count and recency for a single file.
+type FrecencyEntry struct {
+	Count    int       `json:"count"`
+	LastUsed time.Time `json:"last_used"`
+}
+
+// LoadFrecency loads from ~/.ripcode/state/frecency.json.
+// Auto-prunes entries older than 30 days on load.
+func LoadFrecency() (*FileFrecency, error) {
+	f, err := loadState[FileFrecency](frecencyFile, "frecency")
+	if err != nil {
+		return f, err
+	}
+	if f.Entries == nil {
+		f.Entries = make(map[string]FrecencyEntry)
+	}
+	f.Prune(maxFrecencyAge)
+	return f, nil
+}
+
+// Save persists to disk.
+func (f *FileFrecency) Save() error {
+	return saveState(frecencyFile, f)
+}
+
+// Record tracks a file access, incrementing count and updating LastUsed.
+func (f *FileFrecency) Record(path string) {
+	if f.Entries == nil {
+		f.Entries = make(map[string]FrecencyEntry)
+	}
+	e := f.Entries[path]
+	e.Count++
+	e.LastUsed = time.Now()
+	f.Entries[path] = e
+}
+
+// Score computes a frecency score for a path.
+// Score = count * recencyWeight, where recencyWeight = 1.0 / (1.0 + daysSinceLastUse / halfLife).
+// Returns 0 for unknown paths.
+func (f *FileFrecency) Score(path string) float64 {
+	e, ok := f.Entries[path]
+	if !ok {
+		return 0
+	}
+	return f.scoreEntry(e)
+}
+
+func (f *FileFrecency) scoreEntry(e FrecencyEntry) float64 {
+	days := time.Since(e.LastUsed).Hours() / 24.0
+	if days < 0 {
+		days = 0
+	}
+	recencyWeight := 1.0 / (1.0 + days/frecencyHalfLife)
+	return float64(e.Count) * recencyWeight
+}
+
+// Rank sorts paths by frecency score (highest first).
+// Unscored paths are appended in their original order.
+func (f *FileFrecency) Rank(paths []string) []string {
+	if len(paths) == 0 {
+		return nil
+	}
+
+	type scored struct {
+		path  string
+		score float64
+		idx   int // original index for stable sort
+	}
+
+	var scored1 []scored
+	var unscored []string
+
+	for i, p := range paths {
+		s := f.Score(p)
+		if s > 0 {
+			scored1 = append(scored1, scored{path: p, score: s, idx: i})
+		} else {
+			unscored = append(unscored, p)
+		}
+	}
+
+	sort.Slice(scored1, func(i, j int) bool {
+		if math.Abs(scored1[i].score-scored1[j].score) > 1e-9 {
+			return scored1[i].score > scored1[j].score
+		}
+		return scored1[i].idx < scored1[j].idx
+	})
+
+	result := make([]string, 0, len(paths))
+	for _, s := range scored1 {
+		result = append(result, s.path)
+	}
+	result = append(result, unscored...)
+	return result
+}
+
+// Prune removes entries older than maxAge. Returns count of pruned entries.
+func (f *FileFrecency) Prune(maxAge time.Duration) int {
+	if f.Entries == nil {
+		return 0
+	}
+	cutoff := time.Now().Add(-maxAge)
+	pruned := 0
+	for path, e := range f.Entries {
+		if e.LastUsed.Before(cutoff) {
+			delete(f.Entries, path)
+			pruned++
+		}
+	}
+	return pruned
+}

--- a/internal/store/frecency.go
+++ b/internal/store/frecency.go
@@ -15,6 +15,9 @@ const maxFrecencyAge = 30 * 24 * time.Hour
 // At 7 days since last use, the recency weight is 0.5.
 const frecencyHalfLife = 7.0
 
+// scoreEpsilon is the threshold for treating two frecency scores as equal.
+const scoreEpsilon = 1e-9
+
 // FileFrecency tracks file access patterns for frecency-based ranking.
 type FileFrecency struct {
 	Entries map[string]FrecencyEntry `json:"entries"`
@@ -102,7 +105,7 @@ func (f *FileFrecency) Rank(paths []string) []string {
 	}
 
 	sort.Slice(scored1, func(i, j int) bool {
-		if math.Abs(scored1[i].score-scored1[j].score) > 1e-9 {
+		if math.Abs(scored1[i].score-scored1[j].score) > scoreEpsilon {
 			return scored1[i].score > scored1[j].score
 		}
 		return scored1[i].idx < scored1[j].idx

--- a/internal/store/frecency_test.go
+++ b/internal/store/frecency_test.go
@@ -1,0 +1,124 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrecency_Record_IncrementsCount(t *testing.T) {
+	f := &FileFrecency{Entries: make(map[string]FrecencyEntry)}
+	f.Record("main.go")
+	assert.Equal(t, 1, f.Entries["main.go"].Count)
+	f.Record("main.go")
+	assert.Equal(t, 2, f.Entries["main.go"].Count)
+}
+
+func TestFrecency_Record_UpdatesLastUsed(t *testing.T) {
+	f := &FileFrecency{Entries: make(map[string]FrecencyEntry)}
+	before := time.Now()
+	f.Record("main.go")
+	assert.False(t, f.Entries["main.go"].LastUsed.Before(before))
+}
+
+func TestFrecency_Record_NilEntriesMap(t *testing.T) {
+	f := &FileFrecency{}
+	f.Record("file.go")
+	assert.Equal(t, 1, f.Entries["file.go"].Count)
+}
+
+func TestFrecency_Score_NewlyRecordedFile(t *testing.T) {
+	f := &FileFrecency{Entries: make(map[string]FrecencyEntry)}
+	f.Record("main.go")
+	f.Record("main.go")
+	f.Record("main.go")
+	// Just recorded: recencyWeight ≈ 1.0, score ≈ 3.0
+	score := f.Score("main.go")
+	assert.InDelta(t, 3.0, score, 0.1)
+}
+
+func TestFrecency_Score_OldFile(t *testing.T) {
+	f := &FileFrecency{Entries: map[string]FrecencyEntry{
+		"old.go": {Count: 5, LastUsed: time.Now().Add(-14 * 24 * time.Hour)},
+	}}
+	// 14 days old: recencyWeight = 1/(1+14/7) = 1/3 ≈ 0.33; score ≈ 5 * 0.33 = 1.67
+	score := f.Score("old.go")
+	assert.InDelta(t, 1.67, score, 0.1)
+}
+
+func TestFrecency_Score_UnknownFile(t *testing.T) {
+	f := &FileFrecency{Entries: make(map[string]FrecencyEntry)}
+	assert.Equal(t, 0.0, f.Score("unknown.go"))
+}
+
+func TestFrecency_Rank_SortsByScoreDescending(t *testing.T) {
+	now := time.Now()
+	f := &FileFrecency{Entries: map[string]FrecencyEntry{
+		"a.go": {Count: 1, LastUsed: now},
+		"b.go": {Count: 5, LastUsed: now},
+		"c.go": {Count: 3, LastUsed: now},
+	}}
+	ranked := f.Rank([]string{"a.go", "b.go", "c.go"})
+	assert.Equal(t, []string{"b.go", "c.go", "a.go"}, ranked)
+}
+
+func TestFrecency_Rank_UnscoredKeepOriginalOrder(t *testing.T) {
+	now := time.Now()
+	f := &FileFrecency{Entries: map[string]FrecencyEntry{
+		"b.go": {Count: 2, LastUsed: now},
+	}}
+	ranked := f.Rank([]string{"x.go", "b.go", "y.go", "z.go"})
+	assert.Equal(t, []string{"b.go", "x.go", "y.go", "z.go"}, ranked)
+}
+
+func TestFrecency_Rank_EmptyInput(t *testing.T) {
+	f := &FileFrecency{Entries: make(map[string]FrecencyEntry)}
+	assert.Nil(t, f.Rank(nil))
+	assert.Nil(t, f.Rank([]string{}))
+}
+
+func TestFrecency_Prune_RemovesOldEntries(t *testing.T) {
+	f := &FileFrecency{Entries: map[string]FrecencyEntry{
+		"old.go":    {Count: 1, LastUsed: time.Now().Add(-60 * 24 * time.Hour)},
+		"recent.go": {Count: 1, LastUsed: time.Now()},
+	}}
+	pruned := f.Prune(30 * 24 * time.Hour)
+	assert.Equal(t, 1, pruned)
+	assert.NotContains(t, f.Entries, "old.go")
+	assert.Contains(t, f.Entries, "recent.go")
+}
+
+func TestFrecency_Prune_KeepsRecentEntries(t *testing.T) {
+	f := &FileFrecency{Entries: map[string]FrecencyEntry{
+		"a.go": {Count: 1, LastUsed: time.Now()},
+		"b.go": {Count: 1, LastUsed: time.Now().Add(-1 * 24 * time.Hour)},
+	}}
+	pruned := f.Prune(30 * 24 * time.Hour)
+	assert.Equal(t, 0, pruned)
+	assert.Len(t, f.Entries, 2)
+}
+
+func TestFrecency_SaveLoad_Roundtrip(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	f := &FileFrecency{Entries: make(map[string]FrecencyEntry)}
+	f.Record("main.go")
+	f.Record("main.go")
+	f.Record("util.go")
+	require.NoError(t, f.Save())
+
+	loaded, err := LoadFrecency()
+	require.NoError(t, err)
+	assert.Equal(t, 2, loaded.Entries["main.go"].Count)
+	assert.Equal(t, 1, loaded.Entries["util.go"].Count)
+}
+
+func TestFrecency_LoadFrecency_MissingFile(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	f, err := LoadFrecency()
+	require.NoError(t, err)
+	assert.NotNil(t, f)
+	assert.NotNil(t, f.Entries)
+	assert.Empty(t, f.Entries)
+}

--- a/internal/store/frecency_test.go
+++ b/internal/store/frecency_test.go
@@ -114,6 +114,15 @@ func TestFrecency_SaveLoad_Roundtrip(t *testing.T) {
 	assert.Equal(t, 1, loaded.Entries["util.go"].Count)
 }
 
+func TestFrecency_Score_FutureTimestamp(t *testing.T) {
+	f := &FileFrecency{Entries: map[string]FrecencyEntry{
+		"future.go": {Count: 3, LastUsed: time.Now().Add(24 * time.Hour)},
+	}}
+	score := f.Score("future.go")
+	// Future timestamps are clamped to days=0, so recencyWeight=1.0, score=3.0
+	assert.InDelta(t, 3.0, score, 0.1)
+}
+
 func TestFrecency_LoadFrecency_MissingFile(t *testing.T) {
 	t.Setenv("RIPCODE_DIR", t.TempDir())
 	f, err := LoadFrecency()

--- a/internal/tool/diff_test.go
+++ b/internal/tool/diff_test.go
@@ -1,6 +1,7 @@
 package tool
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -147,6 +148,38 @@ func TestCapDiffContent_OverLimit(t *testing.T) {
 	capped := capDiffContent(s)
 	assert.Equal(t, maxDiffContentSize+len("\n[truncated]"), len(capped))
 	assert.True(t, strings.HasSuffix(capped, "\n[truncated]"))
+}
+
+type fixedSizeReader struct {
+	remaining int
+	read      int
+}
+
+func (r *fixedSizeReader) Read(p []byte) (int, error) {
+	if r.remaining == 0 {
+		return 0, io.EOF
+	}
+	n := len(p)
+	if n > r.remaining {
+		n = r.remaining
+	}
+	for i := range p[:n] {
+		p[i] = 'a'
+	}
+	r.remaining -= n
+	r.read += n
+	return n, nil
+}
+
+func TestReadExistingDiffSnapshot_LimitsReadSize(t *testing.T) {
+	r := &fixedSizeReader{remaining: maxDiffContentSize * 4}
+
+	before, binary, err := readExistingDiffSnapshot(r)
+	require.NoError(t, err)
+	assert.False(t, binary)
+	assert.Equal(t, maxDiffContentSize+1, r.read, "reader should be capped at diff limit + sentinel byte")
+	assert.Equal(t, maxDiffContentSize+len("\n[truncated]"), len(before))
+	assert.True(t, strings.HasSuffix(before, "\n[truncated]"))
 }
 
 func TestEdit_EmptyAfter(t *testing.T) {

--- a/internal/tool/diff_test.go
+++ b/internal/tool/diff_test.go
@@ -1,0 +1,180 @@
+package tool
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiffInfo_TypeCreation(t *testing.T) {
+	d := &DiffInfo{Path: "/tmp/test.go", Before: "old", After: "new"}
+	assert.Equal(t, "/tmp/test.go", d.Path)
+	assert.Equal(t, "old", d.Before)
+	assert.Equal(t, "new", d.After)
+	assert.False(t, d.Binary)
+}
+
+func TestEdit_Result_IncludesDiffInfo(t *testing.T) {
+	e := NewEditTool()
+	ctx := newTestCtx(t)
+	path := filepath.Join(ctx.WorkDir, "test.go")
+	require.NoError(t, os.WriteFile(path, []byte("func hello() {\n\treturn\n}\n"), 0644))
+
+	result := e.Execute(ctx, `{"file_path":"`+path+`","old_string":"return","new_string":"return \"world\""}`)
+	require.NoError(t, result.Error)
+	require.NotNil(t, result.Diff)
+	assert.Equal(t, path, result.Diff.Path)
+	assert.Contains(t, result.Diff.Before, "return")
+	assert.Contains(t, result.Diff.After, `return "world"`)
+	assert.False(t, result.Diff.Binary)
+}
+
+func TestEdit_WhitespaceFlexible_IncludesDiffInfo(t *testing.T) {
+	e := NewEditTool()
+	ctx := newTestCtx(t)
+	path := filepath.Join(ctx.WorkDir, "test.go")
+	require.NoError(t, os.WriteFile(path, []byte("func hello() {\n\treturn\n}\n"), 0644))
+
+	result := e.Execute(ctx, `{"file_path":"`+path+`","old_string":"    return","new_string":"    return \"world\""}`)
+	require.NoError(t, result.Error)
+	require.NotNil(t, result.Diff)
+	assert.Contains(t, result.Diff.Before, "return")
+	assert.Contains(t, result.Diff.After, `return "world"`)
+}
+
+func TestWrite_NewFile_EmptyBefore(t *testing.T) {
+	w := NewWriteTool()
+	ctx := newTestCtx(t)
+	path := filepath.Join(ctx.WorkDir, "new.txt")
+
+	result := w.Execute(ctx, `{"file_path":"`+path+`","content":"hello world"}`)
+	require.NoError(t, result.Error)
+	require.NotNil(t, result.Diff)
+	assert.Equal(t, "", result.Diff.Before, "new file should have empty Before")
+	assert.Equal(t, "hello world", result.Diff.After)
+}
+
+func TestWrite_Overwrite_CapturesBefore(t *testing.T) {
+	w := NewWriteTool()
+	ctx := newTestCtx(t)
+	path := filepath.Join(ctx.WorkDir, "existing.txt")
+	require.NoError(t, os.WriteFile(path, []byte("original"), 0644))
+
+	result := w.Execute(ctx, `{"file_path":"`+path+`","content":"updated"}`)
+	require.NoError(t, result.Error)
+	require.NotNil(t, result.Diff)
+	assert.Equal(t, "original", result.Diff.Before)
+	assert.Equal(t, "updated", result.Diff.After)
+}
+
+func TestWrite_SymlinkTarget_RejectsViaOpenNoFollow(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevated privileges on Windows")
+	}
+	ctx := newTestCtx(t)
+	target := filepath.Join(ctx.WorkDir, "real.txt")
+	link := filepath.Join(ctx.WorkDir, "link.txt")
+	require.NoError(t, os.WriteFile(target, []byte("secret"), 0644))
+	require.NoError(t, os.Symlink(target, link))
+
+	w := NewWriteTool()
+	result := w.Execute(ctx, `{"file_path":"`+link+`","content":"hacked"}`)
+	// The write should fail because of symlink rejection in writeAtomic
+	require.Error(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "symlink")
+}
+
+func TestDiffInfo_NilForNonEditWriteTools(t *testing.T) {
+	// Read tool returns no DiffInfo
+	r := NewReadTool()
+	ctx := newTestCtx(t)
+	path := filepath.Join(ctx.WorkDir, "test.txt")
+	require.NoError(t, os.WriteFile(path, []byte("content"), 0644))
+	result := r.Execute(ctx, `{"file_path":"`+path+`"}`)
+	require.NoError(t, result.Error)
+	assert.Nil(t, result.Diff)
+}
+
+func TestIsBinaryContent_WithNullBytes(t *testing.T) {
+	data := []byte("hello\x00world")
+	assert.True(t, isBinaryContent(data))
+}
+
+func TestIsBinaryContent_TextOnly(t *testing.T) {
+	data := []byte("hello world\nthis is text\n")
+	assert.False(t, isBinaryContent(data))
+}
+
+func TestIsBinaryContent_NullByteAfter8KB(t *testing.T) {
+	data := make([]byte, 9000)
+	for i := range data {
+		data[i] = 'a'
+	}
+	data[8193] = 0 // Past 8KB boundary
+	assert.False(t, isBinaryContent(data))
+}
+
+func TestIsBinaryContent_EmptyData(t *testing.T) {
+	assert.False(t, isBinaryContent([]byte{}))
+}
+
+func TestEdit_BinaryFile_DiffInfoBinaryTrue(t *testing.T) {
+	e := NewEditTool()
+	ctx := newTestCtx(t)
+	path := filepath.Join(ctx.WorkDir, "binary.bin")
+	// Binary content with null byte
+	content := "hello\x00world"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+
+	result := e.Execute(ctx, `{"file_path":"`+path+`","old_string":"hello","new_string":"goodbye"}`)
+	require.NoError(t, result.Error)
+	require.NotNil(t, result.Diff)
+	assert.True(t, result.Diff.Binary)
+}
+
+func TestCapDiffContent_UnderLimit(t *testing.T) {
+	s := "short content"
+	assert.Equal(t, s, capDiffContent(s))
+}
+
+func TestCapDiffContent_OverLimit(t *testing.T) {
+	s := strings.Repeat("a", maxDiffContentSize+100)
+	capped := capDiffContent(s)
+	assert.Equal(t, maxDiffContentSize+len("\n[truncated]"), len(capped))
+	assert.True(t, strings.HasSuffix(capped, "\n[truncated]"))
+}
+
+func TestEdit_EmptyAfter(t *testing.T) {
+	e := NewEditTool()
+	ctx := newTestCtx(t)
+	path := filepath.Join(ctx.WorkDir, "test.go")
+	require.NoError(t, os.WriteFile(path, []byte("remove me"), 0644))
+
+	result := e.Execute(ctx, `{"file_path":"`+path+`","old_string":"remove me","new_string":""}`)
+	require.NoError(t, result.Error)
+	require.NotNil(t, result.Diff)
+	assert.Equal(t, "remove me", result.Diff.Before)
+	assert.Equal(t, "", result.Diff.After)
+}
+
+func TestWrite_ConsecutiveWrites_SecondSeesFirst(t *testing.T) {
+	w := NewWriteTool()
+	ctx := newTestCtx(t)
+	path := filepath.Join(ctx.WorkDir, "file.txt")
+
+	r1 := w.Execute(ctx, `{"file_path":"`+path+`","content":"first"}`)
+	require.NoError(t, r1.Error)
+	require.NotNil(t, r1.Diff)
+	assert.Equal(t, "", r1.Diff.Before, "first write: no existing content")
+
+	r2 := w.Execute(ctx, `{"file_path":"`+path+`","content":"second"}`)
+	require.NoError(t, r2.Error)
+	require.NotNil(t, r2.Diff)
+	assert.Equal(t, "first", r2.Diff.Before, "second write: should see first write's content")
+	assert.Equal(t, "second", r2.Diff.After)
+}

--- a/internal/tool/edit.go
+++ b/internal/tool/edit.go
@@ -85,6 +85,8 @@ func (e *EditTool) Execute(ctx Context, argsJSON string) Result {
 	// Try exact match first
 	count := strings.Count(content, args.OldString)
 
+	binary := isBinaryContent(data)
+
 	if count == 0 {
 		// Whitespace-flexible fallback: normalize whitespace and retry
 		newContent, ok := whitespaceFlexibleReplace(content, args.OldString, args.NewString)
@@ -97,6 +99,7 @@ func (e *EditTool) Execute(ctx Context, argsJSON string) Result {
 		return Result{
 			Output: fmt.Sprintf("Edited %s (whitespace-flexible match)", validated),
 			Title:  validated,
+			Diff:   &DiffInfo{Path: validated, Before: capDiffContent(content), After: capDiffContent(newContent), Binary: binary},
 		}
 	}
 
@@ -113,6 +116,7 @@ func (e *EditTool) Execute(ctx Context, argsJSON string) Result {
 	return Result{
 		Output: fmt.Sprintf("Edited %s", validated),
 		Title:  validated,
+		Diff:   &DiffInfo{Path: validated, Before: capDiffContent(content), After: capDiffContent(newContent), Binary: binary},
 	}
 }
 

--- a/internal/tool/grep.go
+++ b/internal/tool/grep.go
@@ -1,7 +1,6 @@
 package tool
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -115,11 +114,7 @@ func (g *GrepTool) Execute(ctx Context, argsJSON string) Result {
 		}
 
 		// Skip binary files
-		checkLen := len(data)
-		if checkLen > 8192 {
-			checkLen = 8192
-		}
-		if bytes.ContainsRune(data[:checkLen], 0) {
+		if isBinaryContent(data) {
 			return nil
 		}
 

--- a/internal/tool/read.go
+++ b/internal/tool/read.go
@@ -1,7 +1,6 @@
 package tool
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -80,12 +79,7 @@ func (r *ReadTool) Execute(ctx Context, argsJSON string) Result {
 		}
 	}
 
-	// Binary detection: check for null bytes in first 8KB
-	checkLen := len(data)
-	if checkLen > 8192 {
-		checkLen = 8192
-	}
-	if bytes.ContainsRune(data[:checkLen], 0) {
+	if isBinaryContent(data) {
 		return Result{
 			Output: fmt.Sprintf("(binary file, %d bytes)", len(data)),
 			Title:  validated,

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -127,11 +127,43 @@ func (c Context) Valid() error {
 	return nil
 }
 
+// maxDiffContentSize caps before/after content at 50KB to prevent memory bloat.
+const maxDiffContentSize = 50 * 1024
+
+// DiffInfo holds before/after file content for diff rendering.
+// Transient — exists only in runtime objects, not persisted in session JSON.
+type DiffInfo struct {
+	Path   string
+	Before string // empty for new files; "[truncated]" suffix if over 50KB
+	After  string
+	Binary bool // true if binary detected (skip diff rendering)
+}
+
+// isBinaryContent checks for null bytes in the first 8KB.
+func isBinaryContent(data []byte) bool {
+	limit := min(len(data), 8192)
+	for _, b := range data[:limit] {
+		if b == 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// capDiffContent truncates content at maxDiffContentSize, appending a marker.
+func capDiffContent(s string) string {
+	if len(s) > maxDiffContentSize {
+		return s[:maxDiffContentSize] + "\n[truncated]"
+	}
+	return s
+}
+
 // Result holds the output of a tool execution.
 type Result struct {
 	Output string
 	Title  string
 	Error  error
+	Diff   *DiffInfo // non-nil for edit/write operations
 }
 
 // Tool defines the interface that all tools must implement.

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -134,7 +134,7 @@ const maxDiffContentSize = 50 * 1024
 // Transient — exists only in runtime objects, not persisted in session JSON.
 type DiffInfo struct {
 	Path   string
-	Before string // empty for new files; "[truncated]" suffix if over 50KB
+	Before string // empty for new files; "\n[truncated]" appended if over 50KB
 	After  string
 	Binary bool // true if binary detected (skip diff rendering)
 }

--- a/internal/tool/write.go
+++ b/internal/tool/write.go
@@ -3,6 +3,7 @@ package tool
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 )
@@ -62,6 +63,17 @@ func (w *WriteTool) Execute(ctx Context, argsJSON string) Result {
 		return Result{Error: fmt.Errorf("stat file: %w", err)}
 	}
 
+	// Capture existing content via OpenNoFollow (symlink-safe) for diff rendering.
+	var before string
+	var beforeBinary bool
+	if f, err := OpenNoFollow(validated, os.O_RDONLY, 0); err == nil {
+		if existingData, err := io.ReadAll(f); err == nil {
+			before = capDiffContent(string(existingData))
+			beforeBinary = isBinaryContent(existingData)
+		}
+		f.Close()
+	}
+
 	// Create parent directories
 	dir := filepath.Dir(validated)
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -75,5 +87,11 @@ func (w *WriteTool) Execute(ctx Context, argsJSON string) Result {
 	return Result{
 		Output: fmt.Sprintf("Wrote %d bytes to %s", len(args.Content), validated),
 		Title:  validated,
+		Diff: &DiffInfo{
+			Path:   validated,
+			Before: before,
+			After:  capDiffContent(args.Content),
+			Binary: beforeBinary || isBinaryContent([]byte(args.Content)),
+		},
 	}
 }

--- a/internal/tool/write.go
+++ b/internal/tool/write.go
@@ -41,6 +41,14 @@ type writeArgs struct {
 	Content  string `json:"content"`
 }
 
+func readExistingDiffSnapshot(r io.Reader) (string, bool, error) {
+	data, err := io.ReadAll(io.LimitReader(r, maxDiffContentSize+1))
+	if err != nil {
+		return "", false, err
+	}
+	return capDiffContent(string(data)), isBinaryContent(data), nil
+}
+
 func (w *WriteTool) Execute(ctx Context, argsJSON string) Result {
 	var args writeArgs
 	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
@@ -67,9 +75,9 @@ func (w *WriteTool) Execute(ctx Context, argsJSON string) Result {
 	var before string
 	var beforeBinary bool
 	if f, err := OpenNoFollow(validated, os.O_RDONLY, 0); err == nil {
-		if existingData, err := io.ReadAll(f); err == nil {
-			before = capDiffContent(string(existingData))
-			beforeBinary = isBinaryContent(existingData)
+		if snap, binary, err := readExistingDiffSnapshot(f); err == nil {
+			before = snap
+			beforeBinary = binary
 		}
 		f.Close()
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -17,6 +17,13 @@ import (
 	"github.com/stephenbrandon/ripcode/internal/tui/components"
 )
 
+// Layout constants used by layout() and chatBounds().
+const (
+	layoutStatusH = 1
+	layoutInputH  = 5
+	layoutFooterH = 1
+)
+
 // AppState represents which screen is active.
 type AppState int
 
@@ -76,12 +83,16 @@ type App struct {
 	forkDialog     forkDialogState
 	mcpDialog      mcpDialogState
 	stashDialog    stashDialogState
+	messageActions messageActionsState
+
+	clipboard Clipboarder
 
 	sidebarHidden    bool
 	sidebarOverlay   bool
 	fileCache        []string
 	fileCacheLoaded  bool
 	fileCacheLoading bool
+	frecency         *store.FileFrecency
 	responseStart    time.Time
 	cancel           context.CancelFunc
 	eventCh          <-chan agent.Event
@@ -142,6 +153,10 @@ func NewApp() App {
 	if err != nil {
 		warnings = append(warnings, fmt.Sprintf("prompt stash: %v, using defaults", err))
 	}
+	frecency, err := store.LoadFrecency()
+	if err != nil {
+		warnings = append(warnings, fmt.Sprintf("frecency: %v, using defaults", err))
+	}
 	summaries, corrupted, err := store.List()
 	if err != nil {
 		warnings = append(warnings, fmt.Sprintf("session list: %v, using defaults", err))
@@ -166,6 +181,8 @@ func NewApp() App {
 		mcpConfig:     mcpCfg,
 		lspConfig:     lspCfg,
 		uiPrefs:       uiPrefs,
+		frecency:      frecency,
+		clipboard:     realClipboard{},
 		sessionsDialog: sessionsDialogState{
 			entries: summaries,
 			loaded:  err == nil,
@@ -192,6 +209,7 @@ func (a *App) closeAllDialogs() {
 	a.forkDialog.open = false
 	a.stashDialog.open = false
 	a.mcpDialog.open = false
+	a.messageActions.open = false
 	a.inline.open = false
 	a.input.Blur()
 }
@@ -406,6 +424,28 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return a, nil
 		}
+		// Chat area click → message actions dialog
+		if a.state == StateSession && !a.streaming {
+			m := msg.Mouse()
+			top, bottom := a.chatBounds()
+			maxX := a.mainContentWidth()
+			if m.Y >= top && m.Y < bottom && m.X < maxX {
+				chatY := m.Y - top + a.chat.ScrollPos()
+				if idx, ok := a.chat.EntryAtLine(chatY); ok {
+					entries := a.chat.Entries()
+					if idx < len(entries) {
+						role := entries[idx].Role
+						if actionsForRole(role) != nil {
+							a.messageActions.open = true
+							a.messageActions.messageIdx = idx
+							a.messageActions.entryRole = role
+							a.messageActions.selected = 0
+							a.input.Blur()
+						}
+					}
+				}
+			}
+		}
 		return a, nil
 
 	case tea.MouseWheelMsg:
@@ -424,19 +464,15 @@ func (a *App) layout() {
 		return
 	}
 
-	statusH := 1
-	inputH := 5
-	footerH := 1
-
 	mainW := a.mainContentWidth()
-	chatH := a.height - statusH - inputH - footerH
+	chatH := a.height - layoutStatusH - layoutInputH - layoutFooterH
 	if chatH < 1 {
 		chatH = 1
 	}
 
 	a.statusbar.SetSize(mainW)
 	a.chat.SetSize(mainW, chatH)
-	a.input.SetSize(mainW, inputH)
+	a.input.SetSize(mainW, layoutInputH)
 	a.footer.SetSize(mainW)
 	if a.sidebarWideVisible() {
 		a.toolpanel.SetSize(a.sidebarWidth())

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -19,9 +19,9 @@ import (
 
 // Layout constants used by layout() and chatBounds().
 const (
-	layoutStatusH = 1
-	layoutInputH  = 5
-	layoutFooterH = 1
+	layoutStatusH = 1 // status bar height in lines
+	layoutInputH  = 5 // input area height (border + 3 content lines + border)
+	layoutFooterH = 1 // footer bar height in lines
 )
 
 // AppState represents which screen is active.

--- a/internal/tui/components/chat.go
+++ b/internal/tui/components/chat.go
@@ -789,8 +789,8 @@ func (c Chat) timestampPrefix(entry ChatEntry, t *styles.Theme) string {
 }
 
 // fileRefPattern matches @file references: requires start-of-string or whitespace before @,
-// captures the path (no spaces or @), with optional :N or :N-M line range suffix.
-// Rejects emails (user@host) because [^\s@] prevents @ in the path portion.
+// captures the path (no spaces, @ or colons), with optional :N or :N-M line range suffix.
+// Rejects emails (user@host) because (?:^|\s) requires whitespace or start-of-string before @.
 var fileRefPattern = regexp.MustCompile(`(?:^|\s)@([^\s@:]+)(?::\d+(?:-\d+)?)?`)
 
 // ParseFileRefs extracts @file references from text.

--- a/internal/tui/components/chat.go
+++ b/internal/tui/components/chat.go
@@ -2,6 +2,8 @@ package components
 
 import (
 	"fmt"
+	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -53,6 +55,16 @@ type MessagePart struct {
 	Content string
 }
 
+// DiffInfo holds before/after content for tool diff rendering.
+// Intentionally separate from tool.DiffInfo for layer separation — TUI components
+// should not import from the tool package.
+type DiffInfo struct {
+	Path   string
+	Before string
+	After  string
+	Binary bool // if true, render "[Binary file changed]" instead of diff
+}
+
 // ChatEntry represents a single rendered entry in the chat.
 type ChatEntry struct {
 	Role       string // RoleUser, RoleAssistant, RoleTool, RoleError, RoleSystem, RoleComplete
@@ -63,6 +75,8 @@ type ChatEntry struct {
 	ToolName   string        // tool name (bash, read, write, etc.)
 	ToolStatus string        // StatusPending, StatusSuccess, StatusError
 	Meta       *CompleteMeta // for RoleComplete entries
+	Diff       *DiffInfo     // optional, for write/edit tool entries (transient, not persisted)
+	FileRefs   []string      // cached @file references (parsed once at creation)
 }
 
 // minContentWidth is the floor for wrapped content width, preventing
@@ -135,6 +149,10 @@ func (c Chat) ShowCodeBlocks() bool { return c.showCodeBlocks }
 func (c *Chat) AddEntry(entry ChatEntry) {
 	if entry.CreatedAt.IsZero() {
 		entry.CreatedAt = time.Now()
+	}
+	// Parse @file refs once at creation for user entries (avoids regex on every render).
+	if entry.Role == RoleUser && entry.FileRefs == nil {
+		entry.FileRefs = ParseFileRefs(entry.Content)
 	}
 	c.entries = append(c.entries, entry)
 	c.streaming = ""
@@ -328,6 +346,25 @@ func (c *Chat) PrevUserMessage() {
 	}
 }
 
+// EntryAtLine maps a rendered line position to a chat entry index.
+// Returns the entry index and true if found, or (0, false) if the line
+// is out of range or there are no entries.
+func (c Chat) EntryAtLine(linePos int) (int, bool) {
+	if linePos < 0 || len(c.entries) == 0 {
+		return 0, false
+	}
+	pos := 0
+	for i, entry := range c.entries {
+		lines := c.renderEntry(entry)
+		entryLines := len(lines) + 1 // +1 for blank separator
+		if linePos < pos+entryLines {
+			return i, true
+		}
+		pos += entryLines
+	}
+	return 0, false
+}
+
 // Entries returns the current chat entries.
 func (c Chat) Entries() []ChatEntry {
 	out := make([]ChatEntry, len(c.entries))
@@ -449,7 +486,7 @@ func (c Chat) renderUserEntry(entry ChatEntry, t *styles.Theme) []string {
 	wrapped := wrapTextWithFirstLineWidth(entry.Content, firstLineWidth, maxWidth)
 	contentLines := strings.Split(wrapped, "\n")
 
-	result := make([]string, 0, len(contentLines)+1)
+	result := make([]string, 0, len(contentLines)+2)
 	for i, line := range contentLines {
 		rendered := accentStyle.Render("┃") + " " + line
 		if i == 0 {
@@ -457,6 +494,20 @@ func (c Chat) renderUserEntry(entry ChatEntry, t *styles.Theme) []string {
 		}
 		result = append(result, rendered)
 	}
+
+	// File attachment badges (pre-parsed at entry creation)
+	if len(entry.FileRefs) > 0 {
+		badgeLine := accentStyle.Render("┃") + " "
+		shown := min(len(entry.FileRefs), maxFileBadges)
+		for _, ref := range entry.FileRefs[:shown] {
+			badgeLine += t.TextMutedStyle.Render("📎 "+filepath.Base(ref)) + "  "
+		}
+		if len(entry.FileRefs) > maxFileBadges {
+			badgeLine += t.TextMutedStyle.Render(fmt.Sprintf("+%d more", len(entry.FileRefs)-maxFileBadges))
+		}
+		result = append(result, badgeLine)
+	}
+
 	result = append(result, accentStyle.Render("╹"))
 	return result
 }
@@ -608,16 +659,27 @@ func (c Chat) renderToolEntry(entry ChatEntry, t *styles.Theme) []string {
 
 	lines := []string{line}
 
-	if c.showDetails && entry.Content != "" && entry.ToolStatus != StatusPending {
-		maxW := c.width - 8
-		if maxW < minContentWidth {
-			maxW = minContentWidth
-		}
-		for _, dl := range strings.Split(entry.Content, "\n") {
-			if lipgloss.Width(dl) > maxW {
-				dl = ansi.Truncate(dl, maxW, "")
+	if c.showDetails && entry.ToolStatus != StatusPending {
+		if entry.Diff != nil && entry.ToolStatus == StatusSuccess {
+			if entry.Diff.Binary {
+				lines = append(lines, "      "+t.TextMutedStyle.Render("[Binary file changed]"))
+			} else if diffLines := ComputeDiff(entry.Diff.Before, entry.Diff.After, 3); len(diffLines) > 0 {
+				for _, dl := range diffLines {
+					lines = append(lines, "      "+RenderDiffLine(dl, t))
+				}
 			}
-			lines = append(lines, "      "+t.TextMutedStyle.Render(dl))
+			// Empty diff (Before == After): skip diff block entirely
+		} else if entry.Content != "" {
+			maxW := c.width - 8
+			if maxW < minContentWidth {
+				maxW = minContentWidth
+			}
+			for _, dl := range strings.Split(entry.Content, "\n") {
+				if lipgloss.Width(dl) > maxW {
+					dl = ansi.Truncate(dl, maxW, "")
+				}
+				lines = append(lines, "      "+t.TextMutedStyle.Render(dl))
+			}
 		}
 	}
 
@@ -725,6 +787,33 @@ func (c Chat) timestampPrefix(entry ChatEntry, t *styles.Theme) string {
 	}
 	return t.TextMutedStyle.Render(entry.CreatedAt.Format("3:04 PM") + "  ")
 }
+
+// fileRefPattern matches @file references: requires start-of-string or whitespace before @,
+// captures the path (no spaces or @), with optional :N or :N-M line range suffix.
+// Rejects emails (user@host) because [^\s@] prevents @ in the path portion.
+var fileRefPattern = regexp.MustCompile(`(?:^|\s)@([^\s@:]+)(?::\d+(?:-\d+)?)?`)
+
+// ParseFileRefs extracts @file references from text.
+// Returns unique file paths found. Handles @path/to/file and @path/to/file:10-20 syntax.
+func ParseFileRefs(text string) []string {
+	matches := fileRefPattern.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(matches))
+	var refs []string
+	for _, m := range matches {
+		path := m[1]
+		if !seen[path] {
+			seen[path] = true
+			refs = append(refs, path)
+		}
+	}
+	return refs
+}
+
+// maxFileBadges is the maximum number of file badges shown before overflow.
+const maxFileBadges = 3
 
 func (c *Chat) scrollToBottom() {
 	c.scrollPos = max(0, c.totalLines()-c.height)

--- a/internal/tui/components/chat_fileref_test.go
+++ b/internal/tui/components/chat_fileref_test.go
@@ -1,0 +1,141 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFileRefs_NoRefs(t *testing.T) {
+	refs := ParseFileRefs("just some text without refs")
+	assert.Nil(t, refs)
+}
+
+func TestParseFileRefs_SingleFile(t *testing.T) {
+	refs := ParseFileRefs("check @file.go please")
+	assert.Equal(t, []string{"file.go"}, refs)
+}
+
+func TestParseFileRefs_WithPath(t *testing.T) {
+	refs := ParseFileRefs("look at @src/main.go")
+	assert.Equal(t, []string{"src/main.go"}, refs)
+}
+
+func TestParseFileRefs_WithLineRange(t *testing.T) {
+	refs := ParseFileRefs("see @file.go:10-20")
+	assert.Equal(t, []string{"file.go"}, refs)
+}
+
+func TestParseFileRefs_SingleLine(t *testing.T) {
+	refs := ParseFileRefs("see @file.go:42")
+	assert.Equal(t, []string{"file.go"}, refs)
+}
+
+func TestParseFileRefs_MultipleRefs(t *testing.T) {
+	refs := ParseFileRefs("compare @a.go and @b.go")
+	assert.Equal(t, []string{"a.go", "b.go"}, refs)
+}
+
+func TestParseFileRefs_Deduped(t *testing.T) {
+	refs := ParseFileRefs("check @file.go then @file.go again")
+	assert.Equal(t, []string{"file.go"}, refs)
+}
+
+func TestParseFileRefs_Email_NotParsed(t *testing.T) {
+	refs := ParseFileRefs("send to user@example.com")
+	assert.Nil(t, refs)
+}
+
+func TestParseFileRefs_DoubleAt_NotParsed(t *testing.T) {
+	refs := ParseFileRefs("@@doubleAt")
+	assert.Nil(t, refs)
+}
+
+func TestParseFileRefs_StartOfLine(t *testing.T) {
+	refs := ParseFileRefs("@file.go is important")
+	assert.Equal(t, []string{"file.go"}, refs)
+}
+
+func TestParseFileRefs_AfterSpace(t *testing.T) {
+	refs := ParseFileRefs("check @file.go")
+	assert.Equal(t, []string{"file.go"}, refs)
+}
+
+func TestParseFileRefs_Relative(t *testing.T) {
+	refs := ParseFileRefs("see @./relative.go")
+	assert.Equal(t, []string{"./relative.go"}, refs)
+}
+
+func TestFileBadge_BaseNameDisplayed(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.AddEntry(ChatEntry{Role: RoleUser, Content: "check @src/internal/main.go"})
+	view := c.View()
+	assert.Contains(t, view, "📎 main.go")
+}
+
+func TestFileBadge_MaxThreeBadges(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.AddEntry(ChatEntry{Role: RoleUser, Content: "check @a.go @b.go @c.go"})
+	view := c.View()
+	assert.Contains(t, view, "📎 a.go")
+	assert.Contains(t, view, "📎 b.go")
+	assert.Contains(t, view, "📎 c.go")
+	assert.NotContains(t, view, "+")
+}
+
+func TestFileBadge_OverflowIndicator(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.AddEntry(ChatEntry{Role: RoleUser, Content: "check @a.go @b.go @c.go @d.go @e.go"})
+	view := c.View()
+	assert.Contains(t, view, "📎 a.go")
+	assert.Contains(t, view, "📎 b.go")
+	assert.Contains(t, view, "📎 c.go")
+	assert.Contains(t, view, "+2 more")
+}
+
+func TestFileBadge_SingleRef_NoOverflow(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.AddEntry(ChatEntry{Role: RoleUser, Content: "see @main.go"})
+	view := c.View()
+	assert.Contains(t, view, "📎 main.go")
+	assert.NotContains(t, view, fmt.Sprintf("+%d more", 0))
+}
+
+func TestFileBadge_NoRefs_NoBadgeLine(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.AddEntry(ChatEntry{Role: RoleUser, Content: "no file refs here"})
+	view := c.View()
+	assert.NotContains(t, view, "📎")
+}
+
+func TestParseFileRefs_AfterNewline(t *testing.T) {
+	refs := ParseFileRefs("first line\n@second.go")
+	assert.Equal(t, []string{"second.go"}, refs)
+}
+
+func TestParseFileRefs_DeepPath(t *testing.T) {
+	refs := ParseFileRefs("check @internal/tui/components/chat.go")
+	assert.Equal(t, []string{"internal/tui/components/chat.go"}, refs)
+}
+
+func TestFileBadge_ShowsBasenameNotFullPath(t *testing.T) {
+	c := NewChat()
+	c.SetSize(120, 20)
+	c.AddEntry(ChatEntry{Role: RoleUser, Content: "see @internal/tui/components/chat.go"})
+	view := c.View()
+	assert.Contains(t, view, "📎 chat.go")
+	// Full path should NOT be in the badge
+	lines := strings.Split(view, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "📎") {
+			assert.NotContains(t, line, "internal/tui/components/chat.go")
+		}
+	}
+}

--- a/internal/tui/components/diff.go
+++ b/internal/tui/components/diff.go
@@ -1,0 +1,86 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/pmezard/go-difflib/difflib"
+
+	"github.com/stephenbrandon/ripcode/internal/tui/styles"
+)
+
+// maxDiffLines caps unified diff output to prevent terminal overflow.
+const maxDiffLines = 30
+
+// maxDiffLineWidth caps individual diff lines to prevent horizontal overflow.
+const maxDiffLineWidth = 200
+
+// ComputeDiff generates a unified diff between before and after strings.
+// Returns nil if content is identical (empty diff).
+// Individual lines are capped at maxDiffLineWidth chars. Total output capped
+// at maxDiffLines lines.
+func ComputeDiff(before, after string, contextLines int) []string {
+	if before == after {
+		return nil
+	}
+
+	diff := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(before),
+		B:        difflib.SplitLines(after),
+		FromFile: "before",
+		ToFile:   "after",
+		Context:  contextLines,
+	}
+
+	text, err := difflib.GetUnifiedDiffString(diff)
+	if err != nil || text == "" {
+		return nil
+	}
+
+	rawLines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+
+	// Skip the --- / +++ file headers (first 2 lines)
+	start := 0
+	for i, line := range rawLines {
+		if strings.HasPrefix(line, "@@") {
+			start = i
+			break
+		}
+	}
+	rawLines = rawLines[start:]
+
+	// Truncate individual lines and cap total count.
+	lines := make([]string, 0, min(len(rawLines), maxDiffLines))
+	for _, line := range rawLines {
+		if len(lines) >= maxDiffLines {
+			remaining := len(rawLines) - maxDiffLines
+			lines = append(lines, fmt.Sprintf("... (%d more lines)", remaining))
+			break
+		}
+		if lipgloss.Width(line) > maxDiffLineWidth {
+			line = ansi.Truncate(line, maxDiffLineWidth, "...")
+		}
+		lines = append(lines, line)
+	}
+
+	return lines
+}
+
+// RenderDiffLine applies color to a single diff line based on its prefix.
+func RenderDiffLine(line string, t *styles.Theme) string {
+	if len(line) == 0 {
+		return line
+	}
+	switch line[0] {
+	case '+':
+		return t.SuccessStyle.Render(line)
+	case '-':
+		return t.ErrorStyle.Render(line)
+	case '@':
+		return t.SecondaryStyle.Render(line)
+	default:
+		return t.TextMutedStyle.Render(line)
+	}
+}

--- a/internal/tui/components/diff.go
+++ b/internal/tui/components/diff.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/pmezard/go-difflib/difflib"
 
+	"github.com/stephenbrandon/ripcode/internal/store"
 	"github.com/stephenbrandon/ripcode/internal/tui/styles"
 )
 
@@ -35,13 +36,17 @@ func ComputeDiff(before, after string, contextLines int) []string {
 	}
 
 	text, err := difflib.GetUnifiedDiffString(diff)
-	if err != nil || text == "" {
+	if err != nil {
+		store.LogError("diff: GetUnifiedDiffString failed", err)
+		return nil
+	}
+	if text == "" {
 		return nil
 	}
 
 	rawLines := strings.Split(strings.TrimRight(text, "\n"), "\n")
 
-	// Skip the --- / +++ file headers (first 2 lines)
+	// Skip lines before the first @@ hunk header (typically --- and +++ file headers)
 	start := 0
 	for i, line := range rawLines {
 		if strings.HasPrefix(line, "@@") {

--- a/internal/tui/components/diff_test.go
+++ b/internal/tui/components/diff_test.go
@@ -1,0 +1,290 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephenbrandon/ripcode/internal/tui/styles"
+)
+
+func TestComputeDiff_NewFile_AllAdditions(t *testing.T) {
+	lines := ComputeDiff("", "line1\nline2\n", 3)
+	require.NotNil(t, lines)
+	hasPlus := false
+	for _, l := range lines {
+		if strings.HasPrefix(l, "+") {
+			hasPlus = true
+		}
+	}
+	assert.True(t, hasPlus, "new file diff should have + lines")
+}
+
+func TestComputeDiff_Identical_ReturnsNil(t *testing.T) {
+	lines := ComputeDiff("same content\n", "same content\n", 3)
+	assert.Nil(t, lines)
+}
+
+func TestComputeDiff_SingleLineChange(t *testing.T) {
+	before := "hello world\n"
+	after := "hello go\n"
+	lines := ComputeDiff(before, after, 3)
+	require.NotNil(t, lines)
+	hasMinus := false
+	hasPlus := false
+	for _, l := range lines {
+		if strings.HasPrefix(l, "-") {
+			hasMinus = true
+		}
+		if strings.HasPrefix(l, "+") {
+			hasPlus = true
+		}
+	}
+	assert.True(t, hasMinus, "should have deletion line")
+	assert.True(t, hasPlus, "should have addition line")
+}
+
+func TestComputeDiff_MultiLineChange(t *testing.T) {
+	before := "line1\nline2\nline3\n"
+	after := "line1\nmodified\nline3\n"
+	lines := ComputeDiff(before, after, 3)
+	require.NotNil(t, lines)
+	assert.True(t, len(lines) > 1)
+}
+
+func TestComputeDiff_AdditionsOnly(t *testing.T) {
+	before := "line1\n"
+	after := "line1\nline2\nline3\n"
+	lines := ComputeDiff(before, after, 3)
+	require.NotNil(t, lines)
+	plusCount := 0
+	minusCount := 0
+	for _, l := range lines {
+		if strings.HasPrefix(l, "+") {
+			plusCount++
+		}
+		if strings.HasPrefix(l, "-") {
+			minusCount++
+		}
+	}
+	assert.Greater(t, plusCount, 0)
+	assert.Equal(t, 0, minusCount, "additions-only diff should have no deletions")
+}
+
+func TestComputeDiff_DeletionsOnly(t *testing.T) {
+	before := "line1\nline2\nline3\n"
+	after := "line1\n"
+	lines := ComputeDiff(before, after, 3)
+	require.NotNil(t, lines)
+	minusCount := 0
+	plusCount := 0
+	for _, l := range lines {
+		if strings.HasPrefix(l, "-") {
+			minusCount++
+		}
+		if strings.HasPrefix(l, "+") {
+			plusCount++
+		}
+	}
+	assert.Greater(t, minusCount, 0)
+	assert.Equal(t, 0, plusCount, "deletions-only diff should have no additions")
+}
+
+func TestComputeDiff_ContextLines(t *testing.T) {
+	var before, after strings.Builder
+	for i := range 20 {
+		if i == 10 {
+			before.WriteString("old line\n")
+			after.WriteString("new line\n")
+		} else {
+			line := strings.Repeat("x", 5) + "\n"
+			before.WriteString(line)
+			after.WriteString(line)
+		}
+	}
+	lines := ComputeDiff(before.String(), after.String(), 3)
+	require.NotNil(t, lines)
+	// Context should include surrounding unchanged lines
+	contextCount := 0
+	for _, l := range lines {
+		if len(l) > 0 && l[0] == ' ' {
+			contextCount++
+		}
+	}
+	assert.LessOrEqual(t, contextCount, 6, "context=3 gives max 6 context lines")
+}
+
+func TestComputeDiff_TruncationAt30Lines(t *testing.T) {
+	var before, after strings.Builder
+	for i := range 50 {
+		before.WriteString(strings.Repeat("a", 5) + "\n")
+		after.WriteString(strings.Repeat("b", 5) + "\n")
+		_ = i
+	}
+	lines := ComputeDiff(before.String(), after.String(), 3)
+	require.NotNil(t, lines)
+	assert.LessOrEqual(t, len(lines), maxDiffLines+1) // +1 for truncation message
+	last := lines[len(lines)-1]
+	assert.Contains(t, last, "more lines")
+}
+
+func TestComputeDiff_LongLineTruncation(t *testing.T) {
+	longLine := strings.Repeat("a", 300) + "\n"
+	shortLine := "b\n"
+	lines := ComputeDiff(longLine, shortLine, 3)
+	require.NotNil(t, lines)
+	for _, l := range lines {
+		if strings.HasPrefix(l, "...") {
+			continue
+		}
+		// Lines are allowed to be truncated at 200 chars
+		// The truncation adds "..." so max is 203
+		assert.LessOrEqual(t, len(l), maxDiffLineWidth+10, "lines should be capped near maxDiffLineWidth")
+	}
+}
+
+func TestRenderDiffLine_Colors(t *testing.T) {
+	theme := styles.DefaultTheme
+	plus := RenderDiffLine("+added", theme)
+	minus := RenderDiffLine("-removed", theme)
+	at := RenderDiffLine("@@ -1,3 +1,3 @@", theme)
+	ctx := RenderDiffLine(" context", theme)
+
+	// Verify lines are styled (contain ANSI sequences)
+	assert.Contains(t, plus, "added")
+	assert.Contains(t, minus, "removed")
+	assert.Contains(t, at, "@@")
+	assert.Contains(t, ctx, "context")
+}
+
+func TestRenderDiffLine_EmptyLine(t *testing.T) {
+	result := RenderDiffLine("", styles.DefaultTheme)
+	assert.Equal(t, "", result)
+}
+
+func TestRenderToolEntry_WithDiff_DetailsOn(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowDetails(true)
+
+	c.AddEntry(ChatEntry{
+		Role:       RoleTool,
+		Content:    "Edited /tmp/test.go",
+		ToolName:   "edit",
+		ToolStatus: StatusSuccess,
+		Diff: &DiffInfo{
+			Path:   "/tmp/test.go",
+			Before: "old content\n",
+			After:  "new content\n",
+		},
+	})
+
+	view := c.View()
+	// Should contain diff lines (colored + and - prefixed lines)
+	assert.Contains(t, view, "old content")
+	assert.Contains(t, view, "new content")
+}
+
+func TestRenderToolEntry_WithDiff_DetailsOff(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowDetails(false)
+
+	c.AddEntry(ChatEntry{
+		Role:       RoleTool,
+		Content:    "Edited /tmp/test.go",
+		ToolName:   "edit",
+		ToolStatus: StatusSuccess,
+		Diff: &DiffInfo{
+			Path:   "/tmp/test.go",
+			Before: "old content\n",
+			After:  "new content\n",
+		},
+	})
+
+	view := c.View()
+	// Should show summary line but NOT diff details
+	assert.Contains(t, view, "edit")
+	assert.NotContains(t, view, "old content")
+}
+
+func TestRenderToolEntry_WithoutDiff_DetailsOn(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowDetails(true)
+
+	c.AddEntry(ChatEntry{
+		Role:       RoleTool,
+		Content:    "found 5 matches",
+		ToolName:   "grep",
+		ToolStatus: StatusSuccess,
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "found 5 matches")
+}
+
+func TestRenderToolEntry_BinaryDiff(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowDetails(true)
+
+	c.AddEntry(ChatEntry{
+		Role:       RoleTool,
+		Content:    "Edited binary.bin",
+		ToolName:   "edit",
+		ToolStatus: StatusSuccess,
+		Diff: &DiffInfo{
+			Path:   "/tmp/binary.bin",
+			Before: "binary\x00data",
+			After:  "new\x00data",
+			Binary: true,
+		},
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "[Binary file changed]")
+}
+
+func TestRenderToolEntry_EmptyDiff_BeforeEqualsAfter(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowDetails(true)
+
+	c.AddEntry(ChatEntry{
+		Role:       RoleTool,
+		Content:    "Edited /tmp/test.go",
+		ToolName:   "edit",
+		ToolStatus: StatusSuccess,
+		Diff: &DiffInfo{
+			Path:   "/tmp/test.go",
+			Before: "same content",
+			After:  "same content",
+		},
+	})
+
+	view := c.View()
+	// Should show summary but no diff block
+	assert.Contains(t, view, "edit")
+	// No diff lines should appear
+	assert.NotContains(t, view, "@@")
+}
+
+func TestRenderToolEntry_NilDiff_NonEditTool(t *testing.T) {
+	c := NewChat()
+	c.SetSize(80, 20)
+	c.SetShowDetails(true)
+
+	c.AddEntry(ChatEntry{
+		Role:       RoleTool,
+		Content:    "3 files found",
+		ToolName:   "glob",
+		ToolStatus: StatusSuccess,
+		Diff:       nil,
+	})
+
+	view := c.View()
+	assert.Contains(t, view, "3 files found")
+}

--- a/internal/tui/dialog_actions.go
+++ b/internal/tui/dialog_actions.go
@@ -1,0 +1,193 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/atotto/clipboard"
+
+	"github.com/stephenbrandon/ripcode/internal/provider"
+	"github.com/stephenbrandon/ripcode/internal/store"
+	"github.com/stephenbrandon/ripcode/internal/tui/components"
+)
+
+// realClipboard wraps atotto/clipboard for production use.
+type realClipboard struct{}
+
+func (realClipboard) WriteAll(text string) error { return clipboard.WriteAll(text) }
+
+// actionsForRole returns the available actions for a chat entry role.
+// Returns nil for roles that don't support actions (system, complete).
+func actionsForRole(role string) []string {
+	switch role {
+	case components.RoleUser:
+		return []string{"Copy", "Revert to here", "Fork from here"}
+	case components.RoleAssistant:
+		return []string{"Copy", "Fork from here"}
+	case components.RoleTool:
+		return []string{"Copy output"}
+	case components.RoleError:
+		return []string{"Copy"}
+	default:
+		return nil
+	}
+}
+
+func (a App) handleMessageActionsDialogKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	actions := actionsForRole(a.messageActions.entryRole)
+
+	switch {
+	case msg.Code == tea.KeyEscape:
+		a.messageActions.open = false
+		a.input.Focus()
+		return a, nil
+
+	case msg.Code == tea.KeyUp:
+		if len(actions) == 0 {
+			return a, nil
+		}
+		a.messageActions.selected--
+		if a.messageActions.selected < 0 {
+			a.messageActions.selected = len(actions) - 1
+		}
+		return a, nil
+
+	case msg.Code == tea.KeyDown:
+		if len(actions) == 0 {
+			return a, nil
+		}
+		a.messageActions.selected++
+		if a.messageActions.selected >= len(actions) {
+			a.messageActions.selected = 0
+		}
+		return a, nil
+
+	case msg.Code == tea.KeyEnter:
+		if len(actions) == 0 {
+			a.messageActions.open = false
+			a.input.Focus()
+			return a, nil
+		}
+		sel := clamp(a.messageActions.selected, 0, len(actions)-1)
+		action := actions[sel]
+		return a.executeMessageAction(action)
+
+	default:
+		return a, nil
+	}
+}
+
+func (a App) executeMessageAction(action string) (tea.Model, tea.Cmd) {
+	a.messageActions.open = false
+	a.input.Focus()
+
+	entries := a.chat.Entries()
+	idx := a.messageActions.messageIdx
+	if idx < 0 || idx >= len(entries) {
+		return a, a.ShowToast("Invalid message index", components.ToastError)
+	}
+	entry := entries[idx]
+
+	switch action {
+	case "Copy", "Copy output":
+		text := entry.CopyableContent()
+		if text == "" {
+			text = entry.Content
+		}
+		if a.clipboard == nil {
+			return a, a.ShowToast("Clipboard not available", components.ToastError)
+		}
+		if err := a.clipboard.WriteAll(text); err != nil {
+			return a, a.ShowToast("Copy failed: "+err.Error(), components.ToastError)
+		}
+		return a, a.ShowToast("Copied to clipboard", components.ToastSuccess)
+
+	case "Revert to here":
+		if a.session == nil {
+			return a, a.ShowToast("No active session", components.ToastError)
+		}
+		if !a.session.CanUndo() {
+			return a, a.ShowToast("Nothing to revert", components.ToastWarning)
+		}
+		// Compute target length: keep the clicked message and its full turn
+		// (i.e. user + following assistant/tool messages before the next user).
+		records := a.session.Records()
+		targetLen := idx + 1
+		for j := targetLen; j < len(records); j++ {
+			if records[j].Message.Role == provider.RoleUser {
+				break
+			}
+			targetLen++
+		}
+		// Revert exchanges until the session length matches.
+		for a.session.Len() > targetLen && a.session.CanUndo() {
+			if _, err := a.session.Revert(); err != nil {
+				break
+			}
+		}
+		a.rebuildChatFromSession()
+		a.chat.AddEntry(components.ChatEntry{
+			Role:    components.RoleSystem,
+			Content: "--- reverted ---",
+		})
+		a.warnOnErr(store.Save(a.session), "session")
+		return a, a.ShowToast("Reverted to message", components.ToastInfo)
+
+	case "Fork from here":
+		if a.session == nil {
+			return a, a.ShowToast("No active session", components.ToastError)
+		}
+		// Find the session record index for this chat entry.
+		// The chat entry idx maps to session records; we fork up to idx.
+		forkIdx := idx
+		if forkIdx >= a.session.Len() {
+			forkIdx = a.session.Len() - 1
+		}
+		if forkIdx < 0 {
+			return a, a.ShowToast("Fork failed: invalid index", components.ToastError)
+		}
+		forked, err := a.session.Fork(forkIdx)
+		if err != nil {
+			return a, a.ShowToast("Fork failed: "+err.Error(), components.ToastError)
+		}
+		if err := store.Save(a.session); err != nil {
+			return a, a.ShowToast("Fork failed: could not save session", components.ToastError)
+		}
+		if err := store.Save(forked); err != nil {
+			return a, a.ShowToast("Fork failed: could not save fork", components.ToastError)
+		}
+		a.session = forked
+		a.rebuildChatFromSession()
+		a.statusbar.SetTitle(shortSessionTitle(forked.ID))
+		a.statusbar.SetTokens(0)
+		return a, a.ShowToast("Forked session", components.ToastSuccess)
+
+	default:
+		store.LogErrorf("dialog_actions: unknown action %q", action)
+		return a, nil
+	}
+}
+
+func (a App) renderMessageActionsDialog() string {
+	actions := actionsForRole(a.messageActions.entryRole)
+	header := fmt.Sprintf("Message actions (Enter select, Esc close)")
+
+	items := make([]pickerItem, len(actions))
+	for i, act := range actions {
+		items[i] = pickerItem{Label: act}
+	}
+	return renderPickerList(header, items, a.messageActions.selected, 8)
+}
+
+// chatBounds returns the Y range of the chat area (top inclusive, bottom exclusive).
+// Uses package-level layout constants from app.go.
+func (a App) chatBounds() (top, bottom int) {
+	top = layoutStatusH
+	if toastView := a.toasts.View(); toastView != "" {
+		top += strings.Count(toastView, "\n") + 1
+	}
+	bottom = a.height - layoutInputH - layoutFooterH
+	return
+}

--- a/internal/tui/dialog_actions.go
+++ b/internal/tui/dialog_actions.go
@@ -9,8 +9,17 @@ import (
 	"github.com/atotto/clipboard"
 
 	"github.com/stephenbrandon/ripcode/internal/provider"
+	"github.com/stephenbrandon/ripcode/internal/session"
 	"github.com/stephenbrandon/ripcode/internal/store"
 	"github.com/stephenbrandon/ripcode/internal/tui/components"
+)
+
+// Action label constants used in actionsForRole and executeMessageAction.
+const (
+	actionCopy       = "Copy"
+	actionCopyOutput = "Copy output"
+	actionRevert     = "Revert to here"
+	actionFork       = "Fork from here"
 )
 
 // realClipboard wraps atotto/clipboard for production use.
@@ -23,16 +32,74 @@ func (realClipboard) WriteAll(text string) error { return clipboard.WriteAll(tex
 func actionsForRole(role string) []string {
 	switch role {
 	case components.RoleUser:
-		return []string{"Copy", "Revert to here", "Fork from here"}
+		return []string{actionCopy, actionRevert, actionFork}
 	case components.RoleAssistant:
-		return []string{"Copy", "Fork from here"}
+		return []string{actionCopy, actionFork}
 	case components.RoleTool:
-		return []string{"Copy output"}
+		return []string{actionCopyOutput}
 	case components.RoleError:
-		return []string{"Copy"}
+		return []string{actionCopy}
 	default:
 		return nil
 	}
+}
+
+// endOfTurn returns the index of the last record in the turn starting at startIdx.
+// A turn is the record at startIdx plus all following non-user records.
+func endOfTurn(records []session.MessageRecord, startIdx int) int {
+	end := startIdx
+	for j := startIdx + 1; j < len(records); j++ {
+		if records[j].Message.Role == provider.RoleUser {
+			break
+		}
+		end = j
+	}
+	return end
+}
+
+func sessionRoleForChatRole(role string) (provider.Role, bool) {
+	switch role {
+	case components.RoleUser:
+		return provider.RoleUser, true
+	case components.RoleAssistant:
+		return provider.RoleAssistant, true
+	case components.RoleTool:
+		return provider.RoleTool, true
+	default:
+		return "", false
+	}
+}
+
+// sessionRecordIndexForChatIndex maps a rendered chat entry index to a concrete
+// session record index, skipping non-session chat rows (system/complete/error).
+func (a App) sessionRecordIndexForChatIndex(chatIdx int) (int, bool) {
+	if a.session == nil {
+		return 0, false
+	}
+	entries := a.chat.Entries()
+	if chatIdx < 0 || chatIdx >= len(entries) {
+		return 0, false
+	}
+
+	records := a.session.Records()
+	recIdx := 0
+	for i, entry := range entries {
+		wantRole, ok := sessionRoleForChatRole(entry.Role)
+		if !ok {
+			continue
+		}
+		for recIdx < len(records) && records[recIdx].Message.Role != wantRole {
+			recIdx++
+		}
+		if recIdx >= len(records) {
+			return 0, false
+		}
+		if i == chatIdx {
+			return recIdx, true
+		}
+		recIdx++
+	}
+	return 0, false
 }
 
 func (a App) handleMessageActionsDialogKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
@@ -91,7 +158,7 @@ func (a App) executeMessageAction(action string) (tea.Model, tea.Cmd) {
 	entry := entries[idx]
 
 	switch action {
-	case "Copy", "Copy output":
+	case actionCopy, actionCopyOutput:
 		text := entry.CopyableContent()
 		if text == "" {
 			text = entry.Content
@@ -104,26 +171,27 @@ func (a App) executeMessageAction(action string) (tea.Model, tea.Cmd) {
 		}
 		return a, a.ShowToast("Copied to clipboard", components.ToastSuccess)
 
-	case "Revert to here":
+	case actionRevert:
 		if a.session == nil {
 			return a, a.ShowToast("No active session", components.ToastError)
 		}
 		if !a.session.CanUndo() {
 			return a, a.ShowToast("Nothing to revert", components.ToastWarning)
 		}
-		// Compute target length: keep the clicked message and its full turn
-		// (i.e. user + following assistant/tool messages before the next user).
-		records := a.session.Records()
-		targetLen := idx + 1
-		for j := targetLen; j < len(records); j++ {
-			if records[j].Message.Role == provider.RoleUser {
-				break
-			}
-			targetLen++
+		recordIdx, ok := a.sessionRecordIndexForChatIndex(idx)
+		if !ok {
+			return a, a.ShowToast("Revert failed: message not found", components.ToastError)
 		}
+		// Keep the clicked message and its full turn (user + following
+		// assistant/tool messages before the next user).
+		records := a.session.Records()
+		targetLen := endOfTurn(records, recordIdx) + 1
 		// Revert exchanges until the session length matches.
+		partial := false
 		for a.session.Len() > targetLen && a.session.CanUndo() {
 			if _, err := a.session.Revert(); err != nil {
+				store.LogErrorf("dialog_actions: revert loop error at session len %d (target %d): %v", a.session.Len(), targetLen, err)
+				partial = true
 				break
 			}
 		}
@@ -133,21 +201,22 @@ func (a App) executeMessageAction(action string) (tea.Model, tea.Cmd) {
 			Content: "--- reverted ---",
 		})
 		a.warnOnErr(store.Save(a.session), "session")
+		if partial {
+			return a, a.ShowToast("Partially reverted (error occurred)", components.ToastWarning)
+		}
 		return a, a.ShowToast("Reverted to message", components.ToastInfo)
 
-	case "Fork from here":
+	case actionFork:
 		if a.session == nil {
 			return a, a.ShowToast("No active session", components.ToastError)
 		}
-		// Find the session record index for this chat entry.
-		// The chat entry idx maps to session records; we fork up to idx.
-		forkIdx := idx
-		if forkIdx >= a.session.Len() {
-			forkIdx = a.session.Len() - 1
+		recordIdx, ok := a.sessionRecordIndexForChatIndex(idx)
+		if !ok {
+			return a, a.ShowToast("Fork failed: message not found", components.ToastError)
 		}
-		if forkIdx < 0 {
-			return a, a.ShowToast("Fork failed: invalid index", components.ToastError)
-		}
+		// Include the full clicked turn up to (but not including) the next user.
+		records := a.session.Records()
+		forkIdx := endOfTurn(records, recordIdx)
 		forked, err := a.session.Fork(forkIdx)
 		if err != nil {
 			return a, a.ShowToast("Fork failed: "+err.Error(), components.ToastError)

--- a/internal/tui/dialog_actions_test.go
+++ b/internal/tui/dialog_actions_test.go
@@ -1,0 +1,523 @@
+package tui
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/stephenbrandon/ripcode/internal/agent"
+	"github.com/stephenbrandon/ripcode/internal/session"
+	"github.com/stephenbrandon/ripcode/internal/store"
+	"github.com/stephenbrandon/ripcode/internal/tool"
+	"github.com/stephenbrandon/ripcode/internal/tui/components"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockClipboard records the last written text for test assertions.
+type mockClipboard struct {
+	written string
+	err     error
+}
+
+func (m *mockClipboard) WriteAll(text string) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.written = text
+	return nil
+}
+
+func makeActionsApp(t *testing.T) App {
+	t.Helper()
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	sess := session.New(t.TempDir())
+	sess.AddUser("hello world")
+	sess.AddAssistant("hello back", nil, nil)
+	app.SetSession(sess)
+	app.SetAgent(agent.BuildAgent())
+	app.clipboard = &mockClipboard{}
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+	a.rebuildChatFromSession()
+	return a
+}
+
+// --- actionsForRole tests ---
+
+func TestActionsForRole_User(t *testing.T) {
+	actions := actionsForRole(components.RoleUser)
+	assert.Equal(t, []string{"Copy", "Revert to here", "Fork from here"}, actions)
+}
+
+func TestActionsForRole_Assistant(t *testing.T) {
+	actions := actionsForRole(components.RoleAssistant)
+	assert.Equal(t, []string{"Copy", "Fork from here"}, actions)
+}
+
+func TestActionsForRole_Tool(t *testing.T) {
+	actions := actionsForRole(components.RoleTool)
+	assert.Equal(t, []string{"Copy output"}, actions)
+}
+
+func TestActionsForRole_Error(t *testing.T) {
+	actions := actionsForRole(components.RoleError)
+	assert.Equal(t, []string{"Copy"}, actions)
+}
+
+func TestActionsForRole_System_Nil(t *testing.T) {
+	actions := actionsForRole(components.RoleSystem)
+	assert.Nil(t, actions)
+}
+
+func TestActionsForRole_Complete_Nil(t *testing.T) {
+	actions := actionsForRole(components.RoleComplete)
+	assert.Nil(t, actions)
+}
+
+// --- Dialog key handling ---
+
+func TestMessageActionsDialog_Escape_Closes(t *testing.T) {
+	a := makeActionsApp(t)
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 0
+	a.messageActions.entryRole = components.RoleUser
+
+	model, _ := a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+}
+
+func TestMessageActionsDialog_UpDown_Navigate(t *testing.T) {
+	a := makeActionsApp(t)
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 0
+	a.messageActions.entryRole = components.RoleUser
+	a.messageActions.selected = 0
+
+	// Down
+	model, _ := a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	result := model.(App)
+	assert.Equal(t, 1, result.messageActions.selected)
+
+	// Down again
+	model, _ = result.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	result = model.(App)
+	assert.Equal(t, 2, result.messageActions.selected)
+
+	// Down at bottom wraps to 0
+	model, _ = result.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyDown})
+	result = model.(App)
+	assert.Equal(t, 0, result.messageActions.selected)
+
+	// Up at top wraps to bottom
+	model, _ = result.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyUp})
+	result = model.(App)
+	assert.Equal(t, 2, result.messageActions.selected)
+}
+
+func TestMessageActionsDialog_Enter_Copy_User(t *testing.T) {
+	a := makeActionsApp(t)
+	clip := &mockClipboard{}
+	a.clipboard = clip
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 0
+	a.messageActions.entryRole = components.RoleUser
+	a.messageActions.selected = 0 // "Copy"
+
+	model, _ := a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+	assert.Equal(t, "hello world", clip.written)
+}
+
+func TestMessageActionsDialog_Enter_Copy_Assistant(t *testing.T) {
+	a := makeActionsApp(t)
+	clip := &mockClipboard{}
+	a.clipboard = clip
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 1
+	a.messageActions.entryRole = components.RoleAssistant
+	a.messageActions.selected = 0 // "Copy"
+
+	model, _ := a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+	assert.Equal(t, "hello back", clip.written)
+}
+
+func TestMessageActionsDialog_Enter_CopyOutput_Tool(t *testing.T) {
+	a := makeActionsApp(t)
+	clip := &mockClipboard{}
+	a.clipboard = clip
+	a.chat.AddEntry(components.ChatEntry{
+		Role:       components.RoleTool,
+		Content:    "tool output here",
+		ToolName:   "bash",
+		ToolStatus: components.StatusSuccess,
+	})
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 2 // the tool entry
+	a.messageActions.entryRole = components.RoleTool
+	a.messageActions.selected = 0 // "Copy output"
+
+	model, _ := a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+	assert.Equal(t, "tool output here", clip.written)
+}
+
+func TestMessageActionsDialog_Enter_Revert(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	sess := session.New(t.TempDir())
+	sess.AddUser("first question")
+	sess.AddAssistant("first answer", nil, nil)
+	sess.AddUser("second question")
+	sess.AddAssistant("second answer", nil, nil)
+	app.SetSession(sess)
+	app.SetAgent(agent.BuildAgent())
+	app.clipboard = &mockClipboard{}
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+	a.rebuildChatFromSession()
+
+	require.True(t, a.session.CanUndo())
+
+	// Open actions on first user message, select "Revert to here"
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 0
+	a.messageActions.entryRole = components.RoleUser
+	a.messageActions.selected = 1 // "Revert to here"
+
+	model, _ = a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+	// Session should have been reverted
+	assert.Equal(t, 2, result.session.Len()) // only first exchange remains
+}
+
+func TestMessageActionsDialog_Enter_Fork(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	sess := session.New(t.TempDir())
+	sess.AddUser("first question")
+	sess.AddAssistant("first answer", nil, nil)
+	sess.AddUser("second question")
+	sess.AddAssistant("second answer", nil, nil)
+	app.SetSession(sess)
+	app.SetAgent(agent.BuildAgent())
+	app.clipboard = &mockClipboard{}
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+	a.rebuildChatFromSession()
+
+	oldID := a.session.ID
+	// Open actions on first user message, select "Fork from here" (index 2)
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 0
+	a.messageActions.entryRole = components.RoleUser
+	a.messageActions.selected = 2 // "Fork from here"
+
+	model, _ = a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+	assert.NotEqual(t, oldID, result.session.ID) // new session
+}
+
+func TestMessageActionsDialog_Renders(t *testing.T) {
+	a := makeActionsApp(t)
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 0
+	a.messageActions.entryRole = components.RoleUser
+	a.messageActions.selected = 1
+
+	output := a.renderMessageActionsDialog()
+	assert.Contains(t, output, "Copy")
+	assert.Contains(t, output, "Revert to here")
+	assert.Contains(t, output, "Fork from here")
+	assert.Contains(t, output, ">") // selection marker
+}
+
+func TestMessageActionsDialog_EmptyActions_Closes(t *testing.T) {
+	a := makeActionsApp(t)
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 0
+	a.messageActions.entryRole = components.RoleSystem // no actions
+
+	model, _ := a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+}
+
+// --- EntryAtLine tests ---
+
+func TestEntryAtLine_FirstEntry(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 40)
+	c.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "hello"})
+	c.AddEntry(components.ChatEntry{Role: components.RoleAssistant, Content: "world"})
+
+	idx, ok := c.EntryAtLine(0)
+	assert.True(t, ok)
+	assert.Equal(t, 0, idx)
+}
+
+func TestEntryAtLine_SecondEntry(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 40)
+	c.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "hello"})
+	c.AddEntry(components.ChatEntry{Role: components.RoleAssistant, Content: "world"})
+
+	// User entry: ┃ hello + ╹ + blank = 3 lines, second entry starts at line 3
+	idx, ok := c.EntryAtLine(3)
+	assert.True(t, ok)
+	assert.Equal(t, 1, idx)
+}
+
+func TestEntryAtLine_OutOfBounds(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 40)
+	c.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "hello"})
+
+	_, ok := c.EntryAtLine(100)
+	assert.False(t, ok)
+}
+
+func TestEntryAtLine_NegativeLine(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 40)
+	c.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "hello"})
+
+	_, ok := c.EntryAtLine(-1)
+	assert.False(t, ok)
+}
+
+func TestEntryAtLine_Empty(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 40)
+
+	_, ok := c.EntryAtLine(0)
+	assert.False(t, ok)
+}
+
+func TestEntryAtLine_MultiLineEntry(t *testing.T) {
+	c := components.NewChat()
+	c.SetSize(80, 40)
+	c.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "line one\nline two\nline three"})
+	c.AddEntry(components.ChatEntry{Role: components.RoleAssistant, Content: "response"})
+
+	// Multi-line user: ┃ line1, ┃ line2, ┃ line3, ╹ = 4 lines + 1 blank = 5
+	// Second entry at line 5
+	idx, ok := c.EntryAtLine(5)
+	assert.True(t, ok)
+	assert.Equal(t, 1, idx)
+}
+
+// --- chatBounds tests ---
+
+func TestChatBounds_Default(t *testing.T) {
+	a := makeActionsApp(t)
+	top, bottom := a.chatBounds()
+	assert.Equal(t, 1, top)     // status bar = 1 line
+	assert.Equal(t, 24, bottom) // height(30) - inputH(5) - footerH(1)
+}
+
+func TestChatBounds_WithToast(t *testing.T) {
+	a := makeActionsApp(t)
+	a.toasts.Show("test", components.ToastInfo, 0)
+
+	top, bottom := a.chatBounds()
+	assert.Greater(t, top, 1)   // toast adds lines above chat
+	assert.Equal(t, 24, bottom) // bottom unchanged
+}
+
+// --- closeAllDialogs includes messageActions ---
+
+func TestCloseAllDialogs_IncludesMessageActions(t *testing.T) {
+	a := makeActionsApp(t)
+	a.messageActions.open = true
+	a.closeAllDialogs()
+	assert.False(t, a.messageActions.open)
+}
+
+// --- handleKey routes to messageActions dialog ---
+
+func TestHandleKey_MessageActionsDialog_Routes(t *testing.T) {
+	a := makeActionsApp(t)
+	a.messageActions.open = true
+	a.messageActions.entryRole = components.RoleUser
+
+	model, _ := a.handleKey(tea.KeyPressMsg{Code: tea.KeyEscape})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+}
+
+// --- Mouse click in chat area opens dialog ---
+
+func TestMouseClick_ChatArea_OpensDialog(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	sess := session.New(t.TempDir())
+	sess.AddUser("hello")
+	sess.AddAssistant("world", nil, nil)
+	app.SetSession(sess)
+	app.SetAgent(agent.BuildAgent())
+	app.clipboard = &mockClipboard{}
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+	a.rebuildChatFromSession()
+
+	// Click at Y=1 (inside chat area), X=5 (inside main content)
+	model, _ = a.Update(tea.MouseClickMsg{X: 5, Y: 1, Button: tea.MouseLeft})
+	result := model.(App)
+	assert.True(t, result.messageActions.open)
+}
+
+func TestMouseClick_OutsideChatArea_NoDialog(t *testing.T) {
+	a := makeActionsApp(t)
+
+	// Click at Y=0 (status bar area)
+	model, _ := a.Update(tea.MouseClickMsg{X: 5, Y: 0, Button: tea.MouseLeft})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+}
+
+func TestMouseClick_StreamingState_NoDialog(t *testing.T) {
+	a := makeActionsApp(t)
+	a.streaming = true
+
+	model, _ := a.Update(tea.MouseClickMsg{X: 5, Y: 2, Button: tea.MouseLeft})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+}
+
+// --- renderSessionView includes messageActions dialog ---
+
+func TestRenderSessionView_IncludesActionsDialog(t *testing.T) {
+	a := makeActionsApp(t)
+	a.messageActions.open = true
+	a.messageActions.entryRole = components.RoleUser
+	a.messageActions.messageIdx = 0
+
+	view := a.renderSessionView()
+	assert.Contains(t, view, "Copy")
+}
+
+// --- Session nil guard for revert/fork ---
+
+func TestMessageActions_RevertNoSession(t *testing.T) {
+	a := makeActionsApp(t)
+	a.session = nil
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 0
+	a.messageActions.entryRole = components.RoleUser
+	a.messageActions.selected = 1 // "Revert to here"
+
+	model, _ := a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+}
+
+func TestMessageActions_ForkNoSession(t *testing.T) {
+	a := makeActionsApp(t)
+	a.session = nil
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 0
+	a.messageActions.entryRole = components.RoleUser
+	a.messageActions.selected = 2 // "Fork from here"
+
+	model, _ := a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+}
+
+// --- Revert to specific message index ---
+
+func TestMessageActions_RevertToSpecificMessage(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	sess := session.New(t.TempDir())
+	sess.AddUser("q1")
+	sess.AddAssistant("a1", nil, nil)
+	sess.AddUser("q2")
+	sess.AddAssistant("a2", nil, nil)
+	sess.AddUser("q3")
+	sess.AddAssistant("a3", nil, nil)
+	require.Equal(t, 6, sess.Len())
+	app.SetSession(sess)
+	app.SetAgent(agent.BuildAgent())
+	app.clipboard = &mockClipboard{}
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+	a.rebuildChatFromSession()
+
+	// Revert from second user message (index 2 in chat: q1, a1, q2)
+	// This should keep q1+a1+q2
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 2 // q2 in chat entries
+	a.messageActions.entryRole = components.RoleUser
+	a.messageActions.selected = 1 // "Revert to here"
+
+	model, _ = a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+	// After revert: should have q1+a1+q2 = 3 messages (reverted q3+a3 = last exchange, keeping q2 prompt)
+	// Actually Revert() removes the last user + following messages, returning the prompt.
+	// With 3 exchanges, Revert() removes q3+a3 (last exchange), returning "q3".
+	// Then another Revert() removes q2+a2, returning "q2".
+	// We need to check session.Len() is reduced.
+	assert.Less(t, result.session.Len(), 6)
+}
+
+// --- Fork from specific message index ---
+
+func TestMessageActions_ForkFromAssistant(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	sess := session.New(t.TempDir())
+	sess.AddUser("q1")
+	sess.AddAssistant("a1", nil, nil)
+	sess.AddUser("q2")
+	sess.AddAssistant("a2", nil, nil)
+	if err := store.Save(sess); err != nil {
+		t.Fatal(err)
+	}
+	app.SetSession(sess)
+	app.SetAgent(agent.BuildAgent())
+	app.clipboard = &mockClipboard{}
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+	a.rebuildChatFromSession()
+
+	oldID := a.session.ID
+	// Fork from assistant entry (index 1 in chat: q1, a1, ...)
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 1
+	a.messageActions.entryRole = components.RoleAssistant
+	a.messageActions.selected = 1 // "Fork from here"
+
+	model, _ = a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+	assert.NotEqual(t, oldID, result.session.ID)
+}

--- a/internal/tui/dialog_actions_test.go
+++ b/internal/tui/dialog_actions_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -51,22 +52,22 @@ func makeActionsApp(t *testing.T) App {
 
 func TestActionsForRole_User(t *testing.T) {
 	actions := actionsForRole(components.RoleUser)
-	assert.Equal(t, []string{"Copy", "Revert to here", "Fork from here"}, actions)
+	assert.Equal(t, []string{actionCopy, actionRevert, actionFork}, actions)
 }
 
 func TestActionsForRole_Assistant(t *testing.T) {
 	actions := actionsForRole(components.RoleAssistant)
-	assert.Equal(t, []string{"Copy", "Fork from here"}, actions)
+	assert.Equal(t, []string{actionCopy, actionFork}, actions)
 }
 
 func TestActionsForRole_Tool(t *testing.T) {
 	actions := actionsForRole(components.RoleTool)
-	assert.Equal(t, []string{"Copy output"}, actions)
+	assert.Equal(t, []string{actionCopyOutput}, actions)
 }
 
 func TestActionsForRole_Error(t *testing.T) {
 	actions := actionsForRole(components.RoleError)
-	assert.Equal(t, []string{"Copy"}, actions)
+	assert.Equal(t, []string{actionCopy}, actions)
 }
 
 func TestActionsForRole_System_Nil(t *testing.T) {
@@ -478,12 +479,9 @@ func TestMessageActions_RevertToSpecificMessage(t *testing.T) {
 	model, _ = a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
 	result := model.(App)
 	assert.False(t, result.messageActions.open)
-	// After revert: should have q1+a1+q2 = 3 messages (reverted q3+a3 = last exchange, keeping q2 prompt)
-	// Actually Revert() removes the last user + following messages, returning the prompt.
-	// With 3 exchanges, Revert() removes q3+a3 (last exchange), returning "q3".
-	// Then another Revert() removes q2+a2, returning "q2".
-	// We need to check session.Len() is reduced.
-	assert.Less(t, result.session.Len(), 6)
+	// After revert: targetLen = 3 (q1=idx0, a1=idx1, q2=idx2 + scan forward: a2 is non-user so targetLen=4).
+	// Session had 6 records. Revert removes q3+a3 (len → 4), which matches targetLen=4.
+	assert.Equal(t, 4, result.session.Len())
 }
 
 // --- Fork from specific message index ---
@@ -520,4 +518,152 @@ func TestMessageActions_ForkFromAssistant(t *testing.T) {
 	result := model.(App)
 	assert.False(t, result.messageActions.open)
 	assert.NotEqual(t, oldID, result.session.ID)
+}
+
+func TestMessageActions_Revert_IgnoresNonSessionChatRows(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	sess := session.New(t.TempDir())
+	sess.AddUser("q1")
+	sess.AddAssistant("a1", nil, nil)
+	sess.AddUser("q2")
+	sess.AddAssistant("a2", nil, nil)
+	sess.AddUser("q3")
+	sess.AddAssistant("a3", nil, nil)
+	require.Equal(t, 6, sess.Len())
+	app.SetSession(sess)
+	app.SetAgent(agent.BuildAgent())
+	app.clipboard = &mockClipboard{}
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+
+	// Build a chat view with extra non-session rows before q2.
+	a.chat.Clear()
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "q1"})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleAssistant, Content: "a1"})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleComplete})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleSystem, Content: "--- marker ---"})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "q2"})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleAssistant, Content: "a2"})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "q3"})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleAssistant, Content: "a3"})
+
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 4 // q2 in chat entries
+	a.messageActions.entryRole = components.RoleUser
+	a.messageActions.selected = 1 // "Revert to here"
+
+	model, _ = a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+	require.Equal(t, 4, result.session.Len(), "revert should target q2 turn even with non-session rows")
+	recs := result.session.Records()
+	require.Len(t, recs, 4)
+	assert.Equal(t, "q2", recs[2].Message.Content)
+	assert.Equal(t, "a2", recs[3].Message.Content)
+}
+
+func TestMessageActions_Fork_IgnoresNonSessionChatRows(t *testing.T) {
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	sess := session.New(t.TempDir())
+	sess.AddUser("q1")
+	sess.AddAssistant("a1", nil, nil)
+	sess.AddUser("q2")
+	sess.AddAssistant("a2", nil, nil)
+	sess.AddUser("q3")
+	sess.AddAssistant("a3", nil, nil)
+	if err := store.Save(sess); err != nil {
+		t.Fatal(err)
+	}
+	app.SetSession(sess)
+	app.SetAgent(agent.BuildAgent())
+	app.clipboard = &mockClipboard{}
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+
+	// Build a chat view with extra non-session rows before q2/a2.
+	a.chat.Clear()
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "q1"})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleAssistant, Content: "a1"})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleComplete})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleSystem, Content: "--- marker ---"})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "q2"})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleAssistant, Content: "a2"})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleUser, Content: "q3"})
+	a.chat.AddEntry(components.ChatEntry{Role: components.RoleAssistant, Content: "a3"})
+
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 5 // a2 in chat entries
+	a.messageActions.entryRole = components.RoleAssistant
+	a.messageActions.selected = 1 // "Fork from here"
+
+	model, _ = a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+	recs := result.session.Records()
+	require.Len(t, recs, 4, "fork should end at clicked turn, not drift to later messages")
+	assert.Equal(t, "q2", recs[2].Message.Content)
+	assert.Equal(t, "a2", recs[3].Message.Content)
+}
+
+// --- ST-1: Clipboard error propagation ---
+
+func TestMessageActions_CopyFails_ShowsErrorToast(t *testing.T) {
+	a := makeActionsApp(t)
+	clip := &mockClipboard{err: fmt.Errorf("clipboard unavailable")}
+	a.clipboard = clip
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 0
+	a.messageActions.entryRole = components.RoleUser
+	a.messageActions.selected = 0 // "Copy"
+
+	model, cmd := a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+	assert.NotNil(t, cmd, "should return toast dismiss command")
+	// The clipboard error should not have written anything
+	assert.Empty(t, clip.written)
+}
+
+func TestMessageActions_CopyNilClipboard_ShowsError(t *testing.T) {
+	a := makeActionsApp(t)
+	a.clipboard = nil
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 0
+	a.messageActions.entryRole = components.RoleUser
+	a.messageActions.selected = 0 // "Copy"
+
+	model, cmd := a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+	assert.NotNil(t, cmd, "should return toast dismiss command for nil clipboard")
+}
+
+// --- actionsForRole unknown role ---
+
+func TestActionsForRole_UnknownRole_Nil(t *testing.T) {
+	actions := actionsForRole("unknown")
+	assert.Nil(t, actions)
+}
+
+// --- Invalid message index bounds ---
+
+func TestMessageActions_InvalidIndex_OutOfBounds(t *testing.T) {
+	a := makeActionsApp(t)
+	a.messageActions.open = true
+	a.messageActions.messageIdx = 999
+	a.messageActions.entryRole = components.RoleUser
+	a.messageActions.selected = 0
+
+	model, cmd := a.handleMessageActionsDialogKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	result := model.(App)
+	assert.False(t, result.messageActions.open)
+	assert.NotNil(t, cmd, "should return error toast for out-of-bounds index")
 }

--- a/internal/tui/dialog_fork.go
+++ b/internal/tui/dialog_fork.go
@@ -6,7 +6,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/stephenbrandon/ripcode/internal/provider"
 	"github.com/stephenbrandon/ripcode/internal/store"
 	"github.com/stephenbrandon/ripcode/internal/tui/components"
 )
@@ -38,15 +37,7 @@ func (a App) handleForkDialogKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		recs := a.session.Records()
 		for i, rec := range recs {
 			if rec.ID == entry.ID {
-				// Include the full turn: selected user message and all
-				// following non-user messages, stopping at the next user.
-				forkIdx = i
-				for j := i + 1; j < len(recs); j++ {
-					if recs[j].Message.Role == provider.RoleUser {
-						break
-					}
-					forkIdx = j
-				}
+				forkIdx = endOfTurn(recs, i)
 				break
 			}
 		}

--- a/internal/tui/dialog_timeline.go
+++ b/internal/tui/dialog_timeline.go
@@ -8,31 +8,64 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/stephenbrandon/ripcode/internal/provider"
+	"github.com/stephenbrandon/ripcode/internal/tui/components"
+	"github.com/stephenbrandon/ripcode/internal/tui/styles"
+)
+
+// Timeline entry status constants.
+const (
+	timelineStatusOK          = "ok"
+	timelineStatusInterrupted = "interrupted"
 )
 
 type timelineEntry struct {
-	ID      string
-	Content string
-	Time    time.Time
+	ID       string
+	Content  string
+	Time     time.Time
+	Tokens   int           // total tokens for this exchange
+	Tools    int           // tool call count
+	Duration time.Duration // assistant response duration
+	Status   string        // timelineStatusOK, timelineStatusInterrupted
 }
 
 func (a App) timelineEntries() []timelineEntry {
 	if a.session == nil {
 		return nil
 	}
+	records := a.session.Records()
 	var entries []timelineEntry
-	for _, rec := range a.session.Records() {
-		if rec.Message.Role == provider.RoleUser {
-			content := rec.Message.Content
-			if len(content) > 60 {
-				content = content[:57] + "..."
-			}
-			entries = append(entries, timelineEntry{
-				ID:      rec.ID,
-				Content: content,
-				Time:    rec.CreatedAt,
-			})
+	for i, rec := range records {
+		if rec.Message.Role != provider.RoleUser {
+			continue
 		}
+		content := rec.Message.Content
+		if len(content) > 60 {
+			content = content[:57] + "..."
+		}
+		entry := timelineEntry{
+			ID:      rec.ID,
+			Content: content,
+			Time:    rec.CreatedAt,
+		}
+		// Scan forward for assistant metadata
+		for j := i + 1; j < len(records); j++ {
+			r := records[j]
+			if r.Message.Role == provider.RoleUser {
+				break
+			}
+			if r.Meta != nil {
+				entry.Tokens = r.Meta.InputTokens + r.Meta.OutputTokens
+				entry.Duration = r.Meta.Duration
+				if r.Meta.FinishReason == "length" {
+					entry.Status = timelineStatusInterrupted
+				}
+			}
+			entry.Tools += len(r.Message.ToolCalls)
+		}
+		if entry.Status == "" {
+			entry.Status = timelineStatusOK
+		}
+		entries = append(entries, entry)
 	}
 	return entries
 }
@@ -79,6 +112,8 @@ func (a *App) scrollToUserMessage(idx int) {
 }
 
 func (a App) renderTimelineDialog() string {
+	muted := styles.DefaultTheme.TextMutedStyle
+
 	var sb strings.Builder
 	sb.WriteString("Timeline (Enter jump, Esc close)\n")
 
@@ -94,6 +129,25 @@ func (a App) renderTimelineDialog() string {
 			marker = "> "
 		}
 		sb.WriteString(fmt.Sprintf("\n%s%s  %s", marker, entry.Time.Format("15:04"), entry.Content))
+
+		// Badge line
+		var badges []string
+		if entry.Tokens > 0 {
+			badges = append(badges, fmt.Sprintf("⊙ %s", components.FormatTokens(entry.Tokens)))
+		}
+		if entry.Tools > 0 {
+			badges = append(badges, fmt.Sprintf("⚡ %d tools", entry.Tools))
+		}
+		if entry.Duration > 0 {
+			badges = append(badges, fmt.Sprintf("%.1fs", entry.Duration.Seconds()))
+		}
+		if entry.Status == timelineStatusInterrupted {
+			badges = append(badges, "⚠ interrupted")
+		}
+		if len(badges) > 0 {
+			indent := "        " // 8 spaces: 2 marker + 5 time + 2 spaces - 1
+			sb.WriteString("\n" + indent + muted.Render(strings.Join(badges, " · ")))
+		}
 	}
 
 	return sb.String()

--- a/internal/tui/dialog_timeline.go
+++ b/internal/tui/dialog_timeline.go
@@ -54,7 +54,7 @@ func (a App) timelineEntries() []timelineEntry {
 				break
 			}
 			if r.Meta != nil {
-				entry.Tokens = r.Meta.InputTokens + r.Meta.OutputTokens
+				entry.Tokens += r.Meta.InputTokens + r.Meta.OutputTokens
 				entry.Duration = r.Meta.Duration
 				if r.Meta.FinishReason == "length" {
 					entry.Status = timelineStatusInterrupted
@@ -136,7 +136,11 @@ func (a App) renderTimelineDialog() string {
 			badges = append(badges, fmt.Sprintf("⊙ %s", components.FormatTokens(entry.Tokens)))
 		}
 		if entry.Tools > 0 {
-			badges = append(badges, fmt.Sprintf("⚡ %d tools", entry.Tools))
+			word := "tools"
+			if entry.Tools == 1 {
+				word = "tool"
+			}
+			badges = append(badges, fmt.Sprintf("⚡ %d %s", entry.Tools, word))
 		}
 		if entry.Duration > 0 {
 			badges = append(badges, fmt.Sprintf("%.1fs", entry.Duration.Seconds()))
@@ -145,7 +149,7 @@ func (a App) renderTimelineDialog() string {
 			badges = append(badges, "⚠ interrupted")
 		}
 		if len(badges) > 0 {
-			indent := "        " // 8 spaces: 2 marker + 5 time + 2 spaces - 1
+			indent := "        " // 8 spaces: aligns with start of message content after "  HH:MM  "
 			sb.WriteString("\n" + indent + muted.Render(strings.Join(badges, " · ")))
 		}
 	}

--- a/internal/tui/dialog_timeline_test.go
+++ b/internal/tui/dialog_timeline_test.go
@@ -175,6 +175,24 @@ func TestTimelineEntries_MultipleExchanges_Independent(t *testing.T) {
 	assert.Equal(t, 300, entries[1].Tokens)
 }
 
+func TestTimelineEntries_SumsTokensAcrossAssistantSteps(t *testing.T) {
+	a := makeTimelineApp(t)
+	a.session.AddUser("multi-step")
+	a.session.AddAssistant("step 1", nil, &session.AssistantMeta{
+		InputTokens:  100,
+		OutputTokens: 50,
+	})
+	a.session.AddToolResult("call-1", "ok")
+	a.session.AddAssistant("step 2", nil, &session.AssistantMeta{
+		InputTokens:  60,
+		OutputTokens: 40,
+	})
+
+	entries := a.timelineEntries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, 250, entries[0].Tokens, "timeline token badge should total all assistant steps in the exchange")
+}
+
 func TestTimelineEntries_Interrupted(t *testing.T) {
 	a := makeTimelineApp(t)
 	a.session.AddUser("long request")
@@ -218,7 +236,23 @@ func TestTimelineBadgeRendering_ToolCount(t *testing.T) {
 	a.timelineDialog.open = true
 
 	rendered := a.renderTimelineDialog()
-	assert.Contains(t, rendered, "⚡ 1 tools")
+	assert.Contains(t, rendered, "⚡ 1 tool")
+	assert.NotContains(t, rendered, "⚡ 1 tools")
+}
+
+func TestTimelineBadgeRendering_ToolCountPlural(t *testing.T) {
+	a := makeTimelineApp(t)
+	a.session.AddUser("tools test")
+	a.session.AddAssistant("using tools", []provider.ToolCall{
+		{ID: "t1", Name: "bash", Args: "{}"},
+		{ID: "t2", Name: "read", Args: "{}"},
+	}, &session.AssistantMeta{InputTokens: 100, OutputTokens: 50})
+	a.session.AddToolResult("t1", "ok")
+	a.session.AddToolResult("t2", "ok")
+	a.timelineDialog.open = true
+
+	rendered := a.renderTimelineDialog()
+	assert.Contains(t, rendered, "⚡ 2 tools")
 }
 
 func TestTimelineBadgeRendering_Interrupted(t *testing.T) {

--- a/internal/tui/dialog_timeline_test.go
+++ b/internal/tui/dialog_timeline_test.go
@@ -3,10 +3,14 @@ package tui
 import (
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/stephenbrandon/ripcode/internal/agent"
+	"github.com/stephenbrandon/ripcode/internal/provider"
 	"github.com/stephenbrandon/ripcode/internal/session"
+	"github.com/stephenbrandon/ripcode/internal/tool"
 	"github.com/stephenbrandon/ripcode/internal/tui/components"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,4 +90,177 @@ func TestApp_TimelineDialog_JumpUsesRenderedLineOffset(t *testing.T) {
 
 	a.scrollToUserMessage(1)
 	assert.Equal(t, expected, a.chat.ScrollPos())
+}
+
+// --- Timeline badge tests ---
+
+func makeTimelineApp(t *testing.T) App {
+	t.Helper()
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	sess := session.New(t.TempDir())
+	app.SetSession(sess)
+	app.SetAgent(agent.BuildAgent())
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	return model.(App)
+}
+
+func TestTimelineEntries_UserOnly_NoBadges(t *testing.T) {
+	a := makeTimelineApp(t)
+	a.session.AddUser("question one")
+	a.session.AddUser("question two")
+
+	entries := a.timelineEntries()
+	require.Len(t, entries, 2)
+	assert.Equal(t, 0, entries[0].Tokens)
+	assert.Equal(t, 0, entries[0].Tools)
+	assert.Equal(t, time.Duration(0), entries[0].Duration)
+	assert.Equal(t, timelineStatusOK, entries[0].Status)
+}
+
+func TestTimelineEntries_WithAssistant_TokensDuration(t *testing.T) {
+	a := makeTimelineApp(t)
+	a.session.AddUser("test prompt")
+	a.session.AddAssistant("response", nil, &session.AssistantMeta{
+		InputTokens:  500,
+		OutputTokens: 300,
+		Duration:     2500 * time.Millisecond,
+		FinishReason: "stop",
+	})
+
+	entries := a.timelineEntries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, 800, entries[0].Tokens)
+	assert.Equal(t, 2500*time.Millisecond, entries[0].Duration)
+	assert.Equal(t, timelineStatusOK, entries[0].Status)
+}
+
+func TestTimelineEntries_WithToolCalls_ToolCount(t *testing.T) {
+	a := makeTimelineApp(t)
+	a.session.AddUser("run some tools")
+	a.session.AddAssistant("I'll help", []provider.ToolCall{
+		{ID: "t1", Name: "bash", Args: "{}"},
+		{ID: "t2", Name: "read", Args: "{}"},
+	}, &session.AssistantMeta{
+		InputTokens:  100,
+		OutputTokens: 50,
+	})
+	a.session.AddToolResult("t1", "output1")
+	a.session.AddToolResult("t2", "output2")
+
+	entries := a.timelineEntries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, 2, entries[0].Tools)
+}
+
+func TestTimelineEntries_MultipleExchanges_Independent(t *testing.T) {
+	a := makeTimelineApp(t)
+	a.session.AddUser("first")
+	a.session.AddAssistant("first response", nil, &session.AssistantMeta{
+		InputTokens:  100,
+		OutputTokens: 50,
+	})
+	a.session.AddUser("second")
+	a.session.AddAssistant("second response", nil, &session.AssistantMeta{
+		InputTokens:  200,
+		OutputTokens: 100,
+	})
+
+	entries := a.timelineEntries()
+	require.Len(t, entries, 2)
+	assert.Equal(t, 150, entries[0].Tokens)
+	assert.Equal(t, 300, entries[1].Tokens)
+}
+
+func TestTimelineEntries_Interrupted(t *testing.T) {
+	a := makeTimelineApp(t)
+	a.session.AddUser("long request")
+	a.session.AddAssistant("partial...", nil, &session.AssistantMeta{
+		FinishReason: "length",
+	})
+
+	entries := a.timelineEntries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, timelineStatusInterrupted, entries[0].Status)
+}
+
+func TestTimelineEntries_EmptySession(t *testing.T) {
+	a := makeTimelineApp(t)
+	entries := a.timelineEntries()
+	assert.Nil(t, entries)
+}
+
+func TestTimelineBadgeRendering_TokensFormatted(t *testing.T) {
+	a := makeTimelineApp(t)
+	a.session.AddUser("test")
+	a.session.AddAssistant("response", nil, &session.AssistantMeta{
+		InputTokens:  800,
+		OutputTokens: 400,
+		Duration:     3 * time.Second,
+	})
+	a.timelineDialog.open = true
+
+	rendered := a.renderTimelineDialog()
+	assert.Contains(t, rendered, "⊙")
+	assert.Contains(t, rendered, "3.0s")
+}
+
+func TestTimelineBadgeRendering_ToolCount(t *testing.T) {
+	a := makeTimelineApp(t)
+	a.session.AddUser("tools test")
+	a.session.AddAssistant("using tools", []provider.ToolCall{
+		{ID: "t1", Name: "bash", Args: "{}"},
+	}, &session.AssistantMeta{InputTokens: 100, OutputTokens: 50})
+	a.session.AddToolResult("t1", "ok")
+	a.timelineDialog.open = true
+
+	rendered := a.renderTimelineDialog()
+	assert.Contains(t, rendered, "⚡ 1 tools")
+}
+
+func TestTimelineBadgeRendering_Interrupted(t *testing.T) {
+	a := makeTimelineApp(t)
+	a.session.AddUser("interrupted test")
+	a.session.AddAssistant("partial", nil, &session.AssistantMeta{
+		FinishReason: "length",
+	})
+	a.timelineDialog.open = true
+
+	rendered := a.renderTimelineDialog()
+	assert.Contains(t, rendered, "⚠ interrupted")
+}
+
+func TestTimelineBadgeRendering_NoBadgesWhenAllZero(t *testing.T) {
+	a := makeTimelineApp(t)
+	a.session.AddUser("just a question")
+	a.timelineDialog.open = true
+
+	rendered := a.renderTimelineDialog()
+	assert.NotContains(t, rendered, "⊙")
+	assert.NotContains(t, rendered, "⚡")
+}
+
+func TestTimelineBadgeRendering_SelectionHighlightPreserved(t *testing.T) {
+	a := makeTimelineApp(t)
+	a.session.AddUser("first")
+	a.session.AddAssistant("r1", nil, &session.AssistantMeta{InputTokens: 100, OutputTokens: 50})
+	a.session.AddUser("second")
+	a.session.AddAssistant("r2", nil, &session.AssistantMeta{InputTokens: 200, OutputTokens: 100})
+	a.timelineDialog.open = true
+	a.timelineDialog.selected = 1
+
+	rendered := a.renderTimelineDialog()
+	lines := strings.Split(rendered, "\n")
+	// Find the selected entry (starts with "> ")
+	found := false
+	for _, line := range lines {
+		if strings.HasPrefix(line, "> ") {
+			found = true
+			assert.Contains(t, line, "second")
+		}
+	}
+	assert.True(t, found, "selected entry should have > marker")
 }

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -53,12 +53,22 @@ func (a App) handleAgentEvent(event agent.Event) (tea.Model, tea.Cmd) {
 			if status == components.StatusError {
 				content = event.Tool.Error
 			}
+			var diff *components.DiffInfo
+			if event.Tool.Diff != nil {
+				diff = &components.DiffInfo{
+					Path:   event.Tool.Diff.Path,
+					Before: event.Tool.Diff.Before,
+					After:  event.Tool.Diff.After,
+					Binary: event.Tool.Diff.Binary,
+				}
+			}
 			a.chat.UpdateLastTool(event.Tool.ID, components.ChatEntry{
 				Role:       components.RoleTool,
 				Content:    content,
 				ToolID:     event.Tool.ID,
 				ToolName:   event.Tool.Name,
 				ToolStatus: status,
+				Diff:       diff,
 			})
 			a.toolpanel.AddEvent(agent.ToolEvent{
 				ID:     event.Tool.ID,

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -419,6 +419,152 @@ func TestApp_ModifiedFiles_FailedEdit_NotTracked(t *testing.T) {
 	assert.Empty(t, a.modifiedFiles.paths(), "failed edit should not be tracked")
 }
 
+// --- ST-5: DiffInfo mapping from tool.DiffInfo → components.DiffInfo ---
+
+func TestApp_ToolEnd_DiffInfoMapping(t *testing.T) {
+	app := NewApp()
+	app.state = StateSession
+	ch := make(chan agent.Event, 1)
+	app.streaming = true
+	app.eventCh = ch
+	app.chat.SetSize(80, 20)
+
+	// Start a tool first so there's an entry to update
+	model, _ := app.Update(AgentEventMsg{
+		Event: agent.Event{
+			Type: agent.EventToolStart,
+			Tool: &agent.ToolEvent{ID: "t1", Name: "edit", Args: `{"file_path":"/tmp/test.go"}`},
+		},
+	})
+	a := model.(App)
+	a.eventCh = ch
+
+	// End the tool with DiffInfo
+	model, _ = a.Update(AgentEventMsg{
+		Event: agent.Event{
+			Type: agent.EventToolEnd,
+			Tool: &agent.ToolEvent{
+				ID:     "t1",
+				Name:   "edit",
+				Output: "edited",
+				Diff: &tool.DiffInfo{
+					Path:   "/tmp/test.go",
+					Before: "old content",
+					After:  "new content",
+					Binary: false,
+				},
+			},
+		},
+	})
+	a = model.(App)
+
+	// Find the tool entry and verify DiffInfo was mapped correctly
+	entries := a.chat.Entries()
+	var toolEntry *components.ChatEntry
+	for i, e := range entries {
+		if e.ToolID == "t1" {
+			toolEntry = &entries[i]
+			break
+		}
+	}
+	require.NotNil(t, toolEntry, "should find tool entry with ID t1")
+	require.NotNil(t, toolEntry.Diff, "tool entry should have DiffInfo")
+	assert.Equal(t, "/tmp/test.go", toolEntry.Diff.Path)
+	assert.Equal(t, "old content", toolEntry.Diff.Before)
+	assert.Equal(t, "new content", toolEntry.Diff.After)
+	assert.False(t, toolEntry.Diff.Binary)
+}
+
+func TestApp_ToolEnd_DiffInfoBinaryMapping(t *testing.T) {
+	app := NewApp()
+	app.state = StateSession
+	ch := make(chan agent.Event, 1)
+	app.streaming = true
+	app.eventCh = ch
+	app.chat.SetSize(80, 20)
+
+	model, _ := app.Update(AgentEventMsg{
+		Event: agent.Event{
+			Type: agent.EventToolStart,
+			Tool: &agent.ToolEvent{ID: "t2", Name: "write", Args: `{"file_path":"/tmp/bin.dat"}`},
+		},
+	})
+	a := model.(App)
+	a.eventCh = ch
+
+	model, _ = a.Update(AgentEventMsg{
+		Event: agent.Event{
+			Type: agent.EventToolEnd,
+			Tool: &agent.ToolEvent{
+				ID:     "t2",
+				Name:   "write",
+				Output: "wrote binary",
+				Diff: &tool.DiffInfo{
+					Path:   "/tmp/bin.dat",
+					Before: "",
+					After:  "binary\x00data",
+					Binary: true,
+				},
+			},
+		},
+	})
+	a = model.(App)
+
+	entries := a.chat.Entries()
+	var toolEntry *components.ChatEntry
+	for i, e := range entries {
+		if e.ToolID == "t2" {
+			toolEntry = &entries[i]
+			break
+		}
+	}
+	require.NotNil(t, toolEntry)
+	require.NotNil(t, toolEntry.Diff)
+	assert.True(t, toolEntry.Diff.Binary)
+}
+
+func TestApp_ToolEnd_NilDiff_NoDiffOnEntry(t *testing.T) {
+	app := NewApp()
+	app.state = StateSession
+	ch := make(chan agent.Event, 1)
+	app.streaming = true
+	app.eventCh = ch
+	app.chat.SetSize(80, 20)
+
+	model, _ := app.Update(AgentEventMsg{
+		Event: agent.Event{
+			Type: agent.EventToolStart,
+			Tool: &agent.ToolEvent{ID: "t3", Name: "bash", Args: `{"command":"ls"}`},
+		},
+	})
+	a := model.(App)
+	a.eventCh = ch
+
+	model, _ = a.Update(AgentEventMsg{
+		Event: agent.Event{
+			Type: agent.EventToolEnd,
+			Tool: &agent.ToolEvent{
+				ID:     "t3",
+				Name:   "bash",
+				Output: "file.txt",
+				Diff:   nil,
+			},
+		},
+	})
+	a = model.(App)
+
+	entries := a.chat.Entries()
+	var toolEntry *components.ChatEntry
+	for i, e := range entries {
+		if e.ToolID == "t3" {
+			toolEntry = &entries[i]
+			break
+		}
+	}
+	require.NotNil(t, toolEntry)
+	assert.Nil(t, toolEntry.Diff, "non-edit tools should have nil Diff")
+}
+
 func TestApp_ModifiedFiles_Deduplicates(t *testing.T) {
 	app := NewApp()
 	app.state = StateSession

--- a/internal/tui/inline.go
+++ b/internal/tui/inline.go
@@ -107,15 +107,47 @@ func (a App) inlineEntries() []inlineEntry {
 	}
 
 	if a.inline.mode == inlineModeFile {
-		out := make([]inlineEntry, 0, 10)
+		// Parse query: split on ":" to get filename and optional line range
+		fileQuery := query
+		lineRange := ""
+		if idx := strings.IndexByte(query, ':'); idx >= 0 {
+			fileQuery = query[:idx]
+			lineRange = query[idx:] // includes the colon
+		}
+		lowerFileQuery := strings.ToLower(fileQuery)
+
+		// Directory expansion: when query ends with "/", show directory contents
+		dirExpand := strings.HasSuffix(fileQuery, "/")
+
+		// Collect matching paths
+		var matched []string
 		for _, path := range a.fileCache {
 			p := strings.ToLower(path)
-			if query != "" && !strings.Contains(p, query) {
-				continue
+			if dirExpand {
+				if strings.HasPrefix(p, lowerFileQuery) {
+					matched = append(matched, path)
+				}
+			} else if lowerFileQuery == "" || strings.Contains(p, lowerFileQuery) {
+				matched = append(matched, path)
+			}
+		}
+
+		// Rank by frecency (frequently used files first)
+		if a.frecency != nil && len(matched) > 0 {
+			matched = a.frecency.Rank(matched)
+		}
+
+		// Build entries with line range preserved in insertion
+		out := make([]inlineEntry, 0, 10)
+		for _, path := range matched {
+			insert := "@" + path + lineRange + " "
+			display := path
+			if lineRange != "" {
+				display = path + lineRange
 			}
 			out = append(out, inlineEntry{
-				Display: path,
-				Insert:  "@" + path + " ",
+				Display: display,
+				Insert:  insert,
 			})
 			if len(out) >= 10 {
 				break
@@ -231,6 +263,17 @@ func (a App) handleInlineKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return a.handleSubmit(choice.Insert)
 		}
 
+		// Record frecency for file selections
+		if a.inline.mode == inlineModeFile && a.frecency != nil {
+			// Extract path from Insert (strip leading @ and trailing space/line range)
+			inserted := strings.TrimPrefix(choice.Insert, "@")
+			inserted = strings.TrimRight(inserted, " ")
+			if idx := strings.IndexByte(inserted, ':'); idx >= 0 {
+				inserted = inserted[:idx]
+			}
+			a.frecency.Record(inserted)
+			a.warnOnErr(a.frecency.Save(), "frecency")
+		}
 		a.input.ReplaceRange(a.inline.start, a.inline.end, choice.Insert)
 		a = a.closeInlineSuggestions()
 		cacheCmd := a.updateInlineSuggestions()

--- a/internal/tui/inline.go
+++ b/internal/tui/inline.go
@@ -116,7 +116,7 @@ func (a App) inlineEntries() []inlineEntry {
 		}
 		lowerFileQuery := strings.ToLower(fileQuery)
 
-		// Directory expansion: when query ends with "/", show directory contents
+		// Directory expansion: when query ends with "/", match files with that prefix path
 		dirExpand := strings.HasSuffix(fileQuery, "/")
 
 		// Collect matching paths

--- a/internal/tui/inline_test.go
+++ b/internal/tui/inline_test.go
@@ -4,12 +4,14 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/stephenbrandon/ripcode/internal/agent"
 	"github.com/stephenbrandon/ripcode/internal/provider"
 	"github.com/stephenbrandon/ripcode/internal/session"
+	"github.com/stephenbrandon/ripcode/internal/store"
 	"github.com/stephenbrandon/ripcode/internal/tool"
 	"github.com/stretchr/testify/assert"
 )
@@ -332,4 +334,164 @@ func TestApp_InlineFileAutocomplete_MultibytePrefixReplacement(t *testing.T) {
 	// Cursor should be positioned after the inserted "@main.go " (rune index 12)
 	// 日(1) 本(2) ' '(3) @(4) m(5) a(6) i(7) n(8) .(9) g(10) o(11) ' '(12)
 	assert.Equal(t, 12, a.input.CursorOffset(), "cursor should be at end of inserted text")
+}
+
+// --- Sub-Phase 6.7: Rich @ Autocomplete ---
+
+func makeInlineFileApp(t *testing.T, files []string) App {
+	t.Helper()
+	t.Setenv("RIPCODE_DIR", t.TempDir())
+	app := NewApp()
+	app.SetProvider(&modelListProvider{})
+	app.SetRegistry(tool.NewRegistry())
+	app.SetSession(session.New(t.TempDir()))
+	app.SetAgent(agent.BuildAgent())
+	app.state = StateSession
+	model, _ := app.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	a := model.(App)
+	a.fileCache = files
+	a.fileCacheLoaded = true
+	return a
+}
+
+func TestInlineFile_FrecencyRanking(t *testing.T) {
+	a := makeInlineFileApp(t, []string{"a.go", "b.go", "c.go"})
+	a.frecency = &store.FileFrecency{Entries: map[string]store.FrecencyEntry{
+		"c.go": {Count: 5, LastUsed: time.Now()},
+		"a.go": {Count: 1, LastUsed: time.Now()},
+	}}
+	a.inline.open = true
+	a.inline.mode = inlineModeFile
+	a.inline.query = ""
+
+	entries := a.inlineEntries()
+	assert.GreaterOrEqual(t, len(entries), 3)
+	// c.go (highest score) should come first
+	assert.Equal(t, "c.go", entries[0].Display)
+	assert.Equal(t, "a.go", entries[1].Display)
+	// b.go (unscored) last
+	assert.Equal(t, "b.go", entries[2].Display)
+}
+
+func TestInlineFile_LineRange_MatchAndInsert(t *testing.T) {
+	a := makeInlineFileApp(t, []string{"main.go", "util.go"})
+	a.inline.open = true
+	a.inline.mode = inlineModeFile
+	a.inline.query = "main.go:10"
+
+	entries := a.inlineEntries()
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "main.go:10", entries[0].Display)
+	assert.Equal(t, "@main.go:10 ", entries[0].Insert)
+}
+
+func TestInlineFile_LineRange_WithRange(t *testing.T) {
+	a := makeInlineFileApp(t, []string{"main.go"})
+	a.inline.open = true
+	a.inline.mode = inlineModeFile
+	a.inline.query = "main.go:10-20"
+
+	entries := a.inlineEntries()
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "main.go:10-20", entries[0].Display)
+	assert.Equal(t, "@main.go:10-20 ", entries[0].Insert)
+}
+
+func TestInlineFile_DirectoryExpansion(t *testing.T) {
+	a := makeInlineFileApp(t, []string{"src/a.go", "src/b.go", "lib/c.go"})
+	a.inline.open = true
+	a.inline.mode = inlineModeFile
+	a.inline.query = "src/"
+
+	entries := a.inlineEntries()
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "src/a.go", entries[0].Display)
+	assert.Equal(t, "src/b.go", entries[1].Display)
+}
+
+func TestInlineFile_DirectoryExpansion_WithPrefix(t *testing.T) {
+	a := makeInlineFileApp(t, []string{"src/comp/a.go", "src/comp/b.go", "src/other.go"})
+	a.inline.open = true
+	a.inline.mode = inlineModeFile
+	a.inline.query = "src/comp"
+
+	entries := a.inlineEntries()
+	assert.Len(t, entries, 2)
+}
+
+func TestInlineFile_SelectionRecordsFrecency(t *testing.T) {
+	a := makeInlineFileApp(t, []string{"main.go"})
+	a.frecency = &store.FileFrecency{Entries: make(map[string]store.FrecencyEntry)}
+	a.inline.open = true
+	a.inline.mode = inlineModeFile
+	a.inline.query = "main"
+	a.inline.start = 0
+	a.inline.end = 5
+	a.input.SetValue("@main")
+
+	model, _ := a.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	a = model.(App)
+	assert.Equal(t, 1, a.frecency.Entries["main.go"].Count, "selection should record frecency")
+}
+
+func TestInlineFile_FrecencyIntegration_RecentlyUsedFirst(t *testing.T) {
+	a := makeInlineFileApp(t, []string{"alpha.go", "beta.go", "gamma.go"})
+	a.frecency = &store.FileFrecency{Entries: map[string]store.FrecencyEntry{
+		"gamma.go": {Count: 10, LastUsed: time.Now()},
+	}}
+	a.inline.open = true
+	a.inline.mode = inlineModeFile
+	a.inline.query = ""
+
+	entries := a.inlineEntries()
+	assert.GreaterOrEqual(t, len(entries), 3)
+	assert.Equal(t, "gamma.go", entries[0].Display, "frecency-ranked file should appear first")
+}
+
+func TestInlineFile_MixedQuery_FrecencyThenAlpha(t *testing.T) {
+	a := makeInlineFileApp(t, []string{"match_a.go", "match_b.go", "match_c.go"})
+	a.frecency = &store.FileFrecency{Entries: map[string]store.FrecencyEntry{
+		"match_b.go": {Count: 3, LastUsed: time.Now()},
+	}}
+	a.inline.open = true
+	a.inline.mode = inlineModeFile
+	a.inline.query = "match"
+
+	entries := a.inlineEntries()
+	assert.Equal(t, "match_b.go", entries[0].Display, "frecency match should come first")
+	assert.Equal(t, "match_a.go", entries[1].Display, "unscored should maintain original order")
+}
+
+func TestInlineFile_NoFrecency_FallbackAlphabetical(t *testing.T) {
+	a := makeInlineFileApp(t, []string{"z.go", "a.go", "m.go"})
+	a.frecency = nil // no frecency loaded
+	a.inline.open = true
+	a.inline.mode = inlineModeFile
+	a.inline.query = ""
+
+	entries := a.inlineEntries()
+	// Should preserve fileCache order (which was alphabetical from WalkDir + sort)
+	assert.Equal(t, "z.go", entries[0].Display)
+	assert.Equal(t, "a.go", entries[1].Display)
+	assert.Equal(t, "m.go", entries[2].Display)
+}
+
+func TestInlineFile_LineRange_NoMatch(t *testing.T) {
+	a := makeInlineFileApp(t, []string{"main.go"})
+	a.inline.open = true
+	a.inline.mode = inlineModeFile
+	a.inline.query = "nonexistent.go:10"
+
+	entries := a.inlineEntries()
+	assert.Empty(t, entries)
+}
+
+func TestInlineFile_DirectoryExpansion_EmptyDir(t *testing.T) {
+	a := makeInlineFileApp(t, []string{"src/a.go"})
+	a.inline.open = true
+	a.inline.mode = inlineModeFile
+	a.inline.query = "lib/"
+
+	entries := a.inlineEntries()
+	assert.Empty(t, entries)
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -23,6 +23,9 @@ func (a App) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case a.statusDialog.open:
 		return a.handleStatusDialogKey(msg)
 
+	case a.messageActions.open:
+		return a.handleMessageActionsDialogKey(msg)
+
 	case a.stashDialog.open:
 		return a.handleStashDialogKey(msg)
 

--- a/internal/tui/models.go
+++ b/internal/tui/models.go
@@ -117,6 +117,18 @@ type stashDialogState struct {
 	pendingContent string // content to stash (captured before input reset)
 }
 
+type messageActionsState struct {
+	open       bool
+	selected   int
+	messageIdx int    // index into chat entries
+	entryRole  string // role of the clicked entry
+}
+
+// Clipboarder abstracts clipboard write for testability.
+type Clipboarder interface {
+	WriteAll(text string) error
+}
+
 // applyVariant updates activeVariant, the status bar badge, and the provider's
 // reasoning effort in one place.
 func (a *App) applyVariant(variant string) {

--- a/internal/tui/sidebar.go
+++ b/internal/tui/sidebar.go
@@ -436,6 +436,10 @@ func (a App) renderSessionView() string {
 		sb.WriteString(a.renderCommandPalette())
 		sb.WriteByte('\n')
 	}
+	if a.messageActions.open {
+		sb.WriteString(a.renderMessageActionsDialog())
+		sb.WriteByte('\n')
+	}
 	if a.inline.open {
 		sb.WriteString(a.renderInlineSuggestions())
 		sb.WriteByte('\n')


### PR DESCRIPTION
## Summary

- **Diff rendering**: `tool.DiffInfo` captures before/after content in edit/write tools; `components.ComputeDiff` (go-difflib) renders colored unified diffs inline in tool entries
- **Timeline badges**: tokens, tool count, duration, and interrupted status shown beneath each timeline dialog entry
- **File attachment badges**: `@file` references parsed from user messages, displayed as 📎 badges (max 3 + overflow) beneath user entries
- **Message click actions dialog**: mouse click on chat entries opens contextual actions (copy, revert to here, fork from here) via `Clipboarder` interface
- **Frecency store**: file access frecency scoring (7-day half-life, 30-day prune) at `~/.ripcode/state/frecency.json`
- **Rich @ autocomplete**: frecency ranking, `@file:N-M` line range syntax, directory expansion (query ending with `/`)

### Simplify review fixes (code quality)
- DRY binary detection: `read.go` and `grep.go` now use shared `isBinaryContent()`
- Timeline status constants: `timelineStatusOK` / `timelineStatusInterrupted`
- Layout dimension constants: `layoutStatusH` / `layoutInputH` / `layoutFooterH` shared between `layout()` and `chatBounds()`
- FileRefs caching: `ParseFileRefs` called once in `AddEntry`, not on every render

## Test plan
- [ ] 1221+ tests passing with `-race` and `go vet` clean
- [ ] Verify diff rendering appears in tool entries when details toggle is on (`leader-d`)
- [ ] Verify timeline dialog (`ctrl+x t`) shows token/tool/duration badges
- [ ] Verify 📎 file badges appear under user messages containing `@file` references
- [ ] Verify clicking a chat message opens the actions dialog with role-appropriate options
- [ ] Verify @ autocomplete ranks recently-used files higher
- [ ] Verify `@file:10-20` syntax works in autocomplete and inserts correctly
- [ ] Verify `@dir/` expands to directory contents in autocomplete